### PR TITLE
Ensure shell history path is present

### DIFF
--- a/script/_tty
+++ b/script/_tty
@@ -25,14 +25,16 @@ source "$DIR/_help"
 ENVIRONMENT="development"
 SERVICE="$1"
 
-local_history="${PWD}/tmp/shell_history"
-touch $local_history
+local_history_path="${PWD}/tmp"
+local_history_file="${local_history_path}/shell_history"
+mkdir -p $local_history_path
+touch $local_history_file
 
 image=$(compose_image_name $SERVICE)
 
 docker run \
   -e HISTFILE=/root/.shell_history \
-  -v $local_history:/root/.shell_history \
+  -v $local_history_file:/root/.shell_history \
   -it \
   --rm \
   $image \


### PR DESCRIPTION
Why:
- If `./tmp` does not exist an error is raised and shell history doesn't work

This change addresses the need by:

Fixes #6
