### PR TITLE
Add support for irb history to console command

### DIFF
--- a/script/_tty
+++ b/script/_tty
@@ -22,13 +22,14 @@ DIR=/bin/script
 source "$DIR/common"
 source "$DIR/_help"
 
-ENVIRONMENT="development"
 SERVICE="$1"
 
 local_history_path="${PWD}/tmp"
-local_history_file="${local_history_path}/shell_history"
+
 mkdir -p $local_history_path
-touch $local_history_file
+
+touch "${local_history_path}/shell_history"
+touch "${local_history_path}/irb_history"
 
 docker-compose run \
   --rm \

--- a/script/console
+++ b/script/console
@@ -4,7 +4,24 @@
 #
 #/* vim: set filetype=sh : */
 
+IRBRC="
+require \"rubygems\"
+require \"irb/completion\"
+require \"irb/ext/save-history\"
+
+# irb configuration
+IRB.conf[:PROMPT_MODE] = :SIMPLE
+IRB.conf[:AUTO_INDENT] = true
+
+# irb history
+IRB.conf[:EVAL_HISTORY] = 10
+IRB.conf[:SAVE_HISTORY] = 1000
+IRB.conf[:HISTORY_FILE] = \"/usr/src/app/irb_history\"
+"
+
 SCRIPT="
+  echo '${IRBRC}' > /root/.irbrc
+
   if hash rails 2>/dev/null ; then
     rails console
   elif hash pry 2>/dev/null ; then


### PR DESCRIPTION
This will inject an `~/.irbc` that sets up irb history and stores it in a local file (`./tmp/irb_history`).

/cc @blankenshipz 
