### PR TITLE
Add bundle command

### DIFF
--- a/script/_help
+++ b/script/_help
@@ -36,6 +36,7 @@ $(print_services)"
 
 COMMANDS=(
   "attach|        |Attach an interactive shell session to a running container"
+  "bundle|        |Run bundle for the given service"
   "bootstrap|     |Runs the bootstrap script for the requested app (or all apps if 'apps' is specified)"
   "console|       |Start a REPL session for the given service"
   "debug|         |Connect to a running byebug server for a given service"

--- a/script/bundle
+++ b/script/bundle
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+source "/bin/script/common"
+source "/bin/script/_help"
+
+service=$(normalize $1)
+
+shift
+
+docker-compose run --rm $service bundle $@


### PR DESCRIPTION
Bundle might be used quite often during development; this helps with
readability  and cuts down on the number of chars required to run the
command.

`> nib run web bundle`

vs:

`> nib bundle web`

This also preserves args to `bundle`

``` sh
> nib bundle web --version
Bundler version 1.11.2
```
