### PR TITLE
Add rails command

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,11 @@ Options:
 
 Commands:
     attach        Attach an interactive shell session to a running container
+    bundle        Run bundle for the given service
     bootstrap     Runs the bootstrap script for the requested app (or all apps if 'apps' is specified)
     console       Start a REPL session for the given service
     debug         Connect to a running byebug server for a given service
+    rails         Run the rails command for the given service
     rake          Run the rake command for the given service
     restart       Restart a running container
     run           Wraps normal 'docker-compose run' to ensure that --rm is always passed

--- a/script/_help
+++ b/script/_help
@@ -40,6 +40,7 @@ COMMANDS=(
   "bootstrap|     |Runs the bootstrap script for the requested app (or all apps if 'apps' is specified)"
   "console|       |Start a REPL session for the given service"
   "debug|         |Connect to a running byebug server for a given service"
+  "rails|         |Run the rails command for the given service"
   "rake|          |Run the rake command for the given service"
   "restart|       |Restart a running container"
   "run|           |Wraps normal 'docker-compose run' to ensure that --rm is always passed"

--- a/script/rails
+++ b/script/rails
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+source "/bin/script/common"
+source "/bin/script/_help"
+
+service=$(normalize $1)
+
+shift
+
+docker-compose run --rm $service rails $@


### PR DESCRIPTION
`rails` is another command that comes up frequently during ruby/rails
development.

This adds a shortcut for brevity:

`> nib run web rails`

becomes

`> nib rails web`

This preserves arguments to rails:

```sh
>nib rails web --version
Rails 5.0.0.beta2
```