### PR TITLE
Ensure console history is in /tmp

### DIFF
--- a/script/_tty
+++ b/script/_tty
@@ -28,9 +28,6 @@ local_history_path="${PWD}/tmp"
 
 mkdir -p $local_history_path
 
-touch "${local_history_path}/shell_history"
-touch "${local_history_path}/irb_history"
-
 docker-compose run \
   --rm \
   -e HISTFILE=/usr/src/app/tmp/shell_history \

--- a/script/console
+++ b/script/console
@@ -16,7 +16,7 @@ IRB.conf[:AUTO_INDENT] = true
 # irb history
 IRB.conf[:EVAL_HISTORY] = 10
 IRB.conf[:SAVE_HISTORY] = 1000
-IRB.conf[:HISTORY_FILE] = \"/usr/src/app/irb_history\"
+IRB.conf[:HISTORY_FILE] = \"/usr/src/app/tmp/irb_history\"
 "
 
 SCRIPT="


### PR DESCRIPTION
Even though `script/_tty` is touching an `irb_history` file inside of
`/tmp`, the file was previously being written inside of the `app`
directory by this `IRB` configuration.

@johnallen3d :eyes: 