### PR TITLE
Upgrade docker components

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:latest
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV COMPOSE_VERSION 1.6.0
+ENV COMPOSE_VERSION 1.7.0
 
 RUN apt-get update -q && \
   apt-get install -y -q --no-install-recommends curl ca-certificates jq git ssh && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,6 @@ ENV COMPOSE_VERSION 1.7.0
 
 RUN apt-get update -q && \
   apt-get install -y -q --no-install-recommends curl ca-certificates jq git ssh && \
-  curl -o /usr/local/bin/docker -L \
-    "https://get.docker.com/builds/Linux/x86_64/docker-latest" && \
-  chmod +x /usr/local/bin/docker && \
   curl -o /usr/local/bin/docker-compose -L \
     "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-Linux-x86_64" && \
   chmod +x /usr/local/bin/docker-compose && \

--- a/script/attach
+++ b/script/attach
@@ -2,6 +2,6 @@
 source "/bin/script/common"
 source "/bin/script/_help"
 
-container=$(compose_container_name $1)
+service=$(normalize $1)
 
-docker exec -it $container /bin/bash
+docker-compose exec $service /bin/bash


### PR DESCRIPTION
Upgrades `docker-compose` to `1.7.0` and removes the dependency `docker` engine

:eyes: @johnallen3d 