### PR TITLE
Reinstates the `update` COMMAND

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update -q && \
 RUN mkdir -p /bin
 
 COPY bin /usr/local/bin
+COPY config /usr/src/nib
 
 ENTRYPOINT ["nib"]
 CMD ["--help"]

--- a/bin/update
+++ b/bin/update
@@ -2,4 +2,6 @@
 
 source "/usr/local/bin/_help"
 
-docker pull technekes/nib:latest
+docker-compose \
+  -f /usr/src/nib/docker-compose.yml \
+  pull nib

--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '2'
+
+# used to faciliate update
+services:
+  nib:
+    image: technekes/nib:latest


### PR DESCRIPTION
A previous [pull request](https://github.com/technekes/nib/pull/18) broke the update feature by removing `docker` as a dependency. This update relies on `docker-compose` (already installed) to get the job done.