### PR TITLE
Adds a method to run the (pull) update with native compose

### DIFF
--- a/bin/update
+++ b/bin/update
@@ -2,4 +2,14 @@
 
 source "/usr/local/bin/_help"
 
-docker pull technekes/nib:latest
+COMPOSE_PATH=/tmp/docker-compose.yml
+
+cat << COMPOSE > $COMPOSE_PATH
+version: '2'
+
+services:
+  nib:
+    image: technekes/nib:latest
+COMPOSE
+
+docker-compose -f $COMPOSE_PATH pull


### PR DESCRIPTION
This fixes a bug introduced by a previous PR: https://github.com/technekes/nib/pull/18 