### PR TITLE
Tag current commit as latest during releaes

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -1,5 +1,14 @@
 #! /bin/bash
 
+# delete local "latest" tag
+git tag -d latest
+
+# delete remote "latest" tag
+git push origin :refs/tags/latest
+
+# tag current commit with "latest"
+git tag latest
+
 # tag with version from VERSION
 git tag $(cat VERSION)
 


### PR DESCRIPTION
This allows for the "latest" tag on the Docker hub to reflect the most
recently released commit.