### PR TITLE
Update alias in README for .docker mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Note:
         --rm \
         -v $(pwd):$(pwd) \
         -w $(pwd) \
-        -v $HOME/.docker/config.json:/root/.docker/config.json:ro \
+        -v $HOME/.docker:/root/.docker:ro \
         -v /var/run/docker.sock:/var/run/docker.sock \
         -e "DOCKER_HOST_URL=$DOCKER_HOST" \
         technekes/nib'
@@ -202,6 +202,7 @@ alias nibdev='
     --rm \
     -v $(pwd):$(pwd) \
     -w $(pwd) \
+    -v $HOME/.docker:/root/.docker:ro \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -e "DOCKER_HOST_URL=$DOCKER_HOST" \
     nibdev:latest'


### PR DESCRIPTION
Previously mounting config.json would cause an issue if the file did not
already exist in the directory, this changes the alias to mount the entire `.docker`
folder to circumvent the issue. 

Per #31 

@johnallen3d @jackross 👀  