### PR TITLE
Reduce Code Duplication

### DIFF
--- a/bin/_standard_command
+++ b/bin/_standard_command
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+source "/usr/local/bin/_common"
+
+service=$(normalize $1)
+
+shift
+
+docker-compose run --rm $service $COMMAND $@

--- a/bin/bundle
+++ b/bin/bundle
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-source "/usr/local/bin/_common"
-source "/usr/local/bin/_help"
+COMMAND="bundle"
 
-service=$(normalize $1)
-
-shift
-
-docker-compose run --rm $service bundle $@
+source "/usr/local/bin/_standard_command"

--- a/bin/guard
+++ b/bin/guard
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-source "/usr/local/bin/_common"
-source "/usr/local/bin/_help"
+COMMAND="guard"
 
-service=$(normalize $1)
-
-shift
-
-docker-compose run --rm $service guard $@
+source "/usr/local/bin/_standard_command"

--- a/bin/rails
+++ b/bin/rails
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-source "/usr/local/bin/_common"
-source "/usr/local/bin/_help"
+COMMAND="rails"
 
-service=$(normalize $1)
-
-shift
-
-docker-compose run --rm $service rails $@
+source "/usr/local/bin/_standard_command"

--- a/bin/rake
+++ b/bin/rake
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-source "/usr/local/bin/_common"
-source "/usr/local/bin/_help"
+COMMAND="rake"
 
-service=$(normalize $1)
-
-shift
-
-docker-compose run --rm $service rake $@
+source "/usr/local/bin/_standard_command"

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-source "/usr/local/bin/_common"
-source "/usr/local/bin/_help"
+COMMAND="rspec"
 
-service=$(normalize $1)
-
-shift
-
-docker-compose run --rm $service rspec $@
+source "/usr/local/bin/_standard_command"

--- a/bin/rubocop
+++ b/bin/rubocop
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-source "/usr/local/bin/_common"
-source "/usr/local/bin/_help"
+COMMAND="rubocop"
 
-service=$(normalize $1)
-
-shift
-
-docker-compose run --rm $service rubocop $@
+source "/usr/local/bin/_standard_command"


### PR DESCRIPTION
Several command scripts were identical except for one word (the name of
the command). This moves the duplicated code into a common script and
the others now just source that.