### PR TITLE
Add version update warning and correct version command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update -q && \
 RUN mkdir -p /bin
 
 COPY bin /usr/local/bin
+COPY VERSION /usr/local/bin
 
 ENTRYPOINT ["nib"]
 CMD ["--help"]

--- a/bin/_help
+++ b/bin/_help
@@ -50,6 +50,21 @@ COMMANDS=(
   "update|        |Download the latest version of the nib tool"
 )
 
+version() {
+  echo $(cat /usr/local/bin/VERSION)
+}
+
+check_for_updates() {
+  LATEST=$(curl --silent https://raw.githubusercontent.com/technekes/nib/master/VERSION)
+  NIB_VERSION=$(version)
+
+  if [ "$NIB_VERSION" != "$LATEST" ]; then
+    echo ""
+    echo "An update avaiable is available for nib: $LATEST"
+    echo "Use 'nib update' to pull the latest version"
+  fi
+}
+
 print_commands() {
   echo "Commands:"
   for COMMAND in "${COMMANDS[@]}"; do
@@ -65,10 +80,13 @@ case $1 in
       show_common_help
     fi
 
+    check_for_updates
     exit 0
     ;;
   --version|version)
-    cat VERSION
+    version
+
+    check_for_updates
     exit 0
     ;;
 esac

--- a/bin/_help
+++ b/bin/_help
@@ -55,7 +55,7 @@ version() {
 }
 
 check_for_updates() {
-  LATEST=$(curl --silent https://raw.githubusercontent.com/technekes/nib/master/VERSION)
+  LATEST=$(curl --silent https://raw.githubusercontent.com/technekes/nib/latest/VERSION)
   NIB_VERSION=$(version)
 
   if [ "$NIB_VERSION" != "$LATEST" ]; then


### PR DESCRIPTION
In the case that a user asks for help, take the opprotunity to ensure
they're running the latest version of `nib`. This also corrects a
problem where the `--version` command was not working because the
`VERSION` file was not mounted into the image.

@johnallen3d :eyes: 