### PR TITLE
Switch Base Image to Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,17 @@
-FROM debian:latest
+FROM alpine:latest
 
 ENV COMPOSE_VERSION 1.7.1
 
 RUN \
-  apt-get update -q && \
-  apt-get install -y -q --no-install-recommends curl ca-certificates jq git ssh && \
-  curl -o /usr/local/bin/docker-compose -L \
-    "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-Linux-x86_64" && \
-  chmod +x /usr/local/bin/docker-compose && \
-  rm -rf \
-    # Clean up any temporary files:
-    /tmp/* \
-    # Clean up the pip cache:
-    /root/.cache \
-    # Clean up the cache:
-    /var/lib/apt/lists/* \
-    /tmp/* /var/tmp/* \
-    # Remove any compiled python files (compile on demand):
-    `find / -regex '.*\.py[co]'`
+  apk add --update \
+    bash \
+    curl \
+    jq \
+    py-pip \
+    py-yaml && \
+  pip install -U docker-compose==${COMPOSE_VERSION} &&\
+  rm /var/cache/apk/* && \
+  rm -rf `find / -regex '.*\.py[co]' -or -name apk`
 
 COPY bin /usr/local/bin
 COPY VERSION /usr/local/bin


### PR DESCRIPTION
This reduces the images size from ~210 MB to ~40 MB. Historically we had
issues related to bind mounting local volumes but I can not currently
reproduce.

In addition the dependencies of `git` and `ssh` have been removed which
would resolve #41.