### PR TITLE
Remove the need for the `.nib` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,20 +162,6 @@ web:
     - "RUBY_DEBUG_PORT=3001"
 ```
 
-Tell nib what port you are using by adding a configuration file (`.nib` JSON) specifying the service name and port.
-
-```json
-// .nib
-{
-  "services": [
-    {
-       "name": "web",
-       "ruby_debug_port": "3001"
-    }
-  ]
-}
-```
-
 Once all of this is in place and the web service is up and running (`nib up`) you can use the `debug` command to attach to the remote debugger.
 
 ```sh

--- a/bin/_common
+++ b/bin/_common
@@ -7,12 +7,22 @@ NC='\033[0m' # No Color
 
 COMMAND=`basename "$0"`
 
-repos() {
-  echo $(cat .nib | jq -r '.services | map(.repository) | unique | .[]')
+compose_json() {
+  cat docker-compose.yml | yaml2json
+}
+
+compose_version2() {
+  grep -q "version.*2" docker-compose.yml
 }
 
 services() {
-  echo $(cat .nib | jq -r '.services[] | .name')
+  prefix=""
+
+  if compose_version2 ; then
+    prefix=".services | "
+  fi
+
+  echo $(compose_json | jq "${prefix}keys")
 }
 
 fancy_echo() {

--- a/bin/_help
+++ b/bin/_help
@@ -18,7 +18,7 @@ print_help_options() {
 }
 
 print_services() {
-  echo "  " $(printf -- '%s\n' $(services))
+  echo $(services) | jq -r "\"  - \(.[])\""
 }
 
 print_command_instructions() {

--- a/bin/debug
+++ b/bin/debug
@@ -15,12 +15,24 @@ show_help() {
 }
 
 source "/usr/local/bin/_help"
+source "/usr/local/bin/_common"
 
 ruby_debug_port() {
-  PORT=$(
-    cat .nib | \
-    jq -r ".services[] | select(.name==\"$1\") | .ruby_debug_port"
+  PREFIX=""
+
+  if compose_version2 ; then
+    PREFIX=".services"
+  fi
+
+  DEBUG_SETTING=$(
+    compose_json | \
+      jq "${PREFIX}.$1.environment" | \
+      grep "RUBY_DEBUG_PORT" | \
+      tr ':' '=' | \
+      tr '[,"]' ' '
   )
+
+  PORT="${DEBUG_SETTING#*=}"
 
   if [ -z "$PORT" ] || [ "null" == "$PORT" ]; then
     exit 1
@@ -39,14 +51,11 @@ fi
 
 if [ -z "$1" ]; then
   show_help
-elif [ ! -f .nib ]; then
-  echo "The .nib file is missing; cannot determine ruby_debug_port"
-  show_help
 else
   RUBY_DEBUG_PORT=$(ruby_debug_port $SERVICE)
 
   if [ $? == 1 ]; then
-    echo "The service is not defined in .nib or the ruby_debug_port is missing"
+    echo "The service is not defined or the ruby_debug_port is missing"
     show_help
     exit 1
   fi


### PR DESCRIPTION
The primary reason for the `.nib` file currently is for the debug command. This change uses a tool to convert the `docker-compose.yml` into JSON which is then parsable by `jq`.

Resolves #38