### PR TITLE
Tighten up command help grep

### DIFF
--- a/bin/_help
+++ b/bin/_help
@@ -22,7 +22,7 @@ print_services() {
 }
 
 print_command_instructions() {
-  echo "  " $(printf -- '%s\n' "${COMMANDS[@]}" | grep $COMMAND | awk -F '|' '{print $3}')
+  echo "  " $(printf -- '%s\n' "${COMMANDS[@]}" | grep "${COMMAND}|" | awk -F '|' '{print $3}')
 }
 
 show_common_help() {


### PR DESCRIPTION
Before this change when searching the `$COMMANDS` array for something like the command "run" several results came back because it's a commonly used word. With this change in place we are now searching for "run|".