### PR TITLE
Use commands config to execute wrapper commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN \
   rm /var/cache/apk/* && \
   rm -rf `find / -regex '.*\.py[co]' -or -name apk`
 
+COPY config /usr/local/bin/config
 COPY bin /usr/local/bin
 COPY VERSION /usr/local/bin
 

--- a/bin/bundle
+++ b/bin/bundle
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-COMMAND="bundle"
-
-source "/usr/local/bin/_standard_command"

--- a/bin/guard
+++ b/bin/guard
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-COMMAND="guard"
-
-source "/usr/local/bin/_standard_command"

--- a/bin/nib
+++ b/bin/nib
@@ -24,13 +24,25 @@ Note:
 DIR=/usr/local/bin
 source "$DIR/_help"
 
+is_wrapped_command() {
+  query=".[] | select( .name == \"$1\" ) | select( .type == \"wrap\" )"
+
+  if [[ $(cat $DIR/config/commands.json | jq -r "$query") ]]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
 if [[ $# -eq 0 ]] ; then
-    show_help
-    exit 0
+  show_help
+  exit 0
 fi
 
 if [ ! -f "$DIR/$1" ]; then
-    docker-compose $@
+  docker-compose $@
+elif is_wrapped_command $1 ; then
+  $DIR/wrap_command $@
 else
-    $DIR/$@
+  $DIR/$@
 fi

--- a/bin/rails
+++ b/bin/rails
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-COMMAND="rails"
-
-source "/usr/local/bin/_standard_command"

--- a/bin/rake
+++ b/bin/rake
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-COMMAND="rake"
-
-source "/usr/local/bin/_standard_command"

--- a/bin/rspec
+++ b/bin/rspec
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-COMMAND="rspec"
-
-source "/usr/local/bin/_standard_command"

--- a/bin/rubocop
+++ b/bin/rubocop
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-COMMAND="rubocop"
-
-source "/usr/local/bin/_standard_command"

--- a/bin/wrap_command
+++ b/bin/wrap_command
@@ -2,8 +2,11 @@
 
 source "/usr/local/bin/_common"
 
-service=$(normalize $1)
+COMMAND=$1
 
+service=$(normalize $2)
+
+shift
 shift
 
 docker-compose run --rm $service $COMMAND $@

--- a/config/commands.json
+++ b/config/commands.json
@@ -1,0 +1,67 @@
+[
+  {
+    "name": "attach",
+    "type": "custom",
+    "description": "Attach an interactive shell session to a running container"
+  },
+  {
+    "name": "bootstrap",
+    "type": "custom",
+    "description": "Runs the bootstrap script for the requested app (or all apps if 'apps' is specified)"
+  },
+  {
+    "name": "bundle",
+    "type": "wrap",
+    "description": "Run bundle for the given service"
+  },
+  {
+    "name": "console",
+    "type": "custom",
+    "description": "Start a REPL session for the given service"
+  },
+  {
+    "name": "debug",
+    "type": "custom",
+    "description": "Connect to a running byebug server for a given service"
+  },
+  {
+    "name": "guard",
+    "type": "wrap",
+    "description": "Run the guard command for the given service"
+  },
+  {
+    "name": "rails",
+    "type": "wrap",
+    "description": "Run the rails command for the given service"
+  },
+  {
+    "name": "rake",
+    "type": "wrap",
+    "description": "Run the rake command for the given service"
+  },
+  {
+    "name": "rspec",
+    "type": "wrap",
+    "description": "Runs the rspec command for the given service"
+  },
+  {
+    "name": "rubocop",
+    "type": "wrap",
+    "description": "Runs the rubocop command for the given service"
+  },
+  {
+    "name": "run",
+    "type": "custom",
+    "description": "Wraps normal 'docker-compose run' to ensure that --rm is always passed"
+  },
+  {
+    "name": "shell",
+    "type": "custom",
+    "description": "Start a shell session in a one-off service container"
+  },
+  {
+    "name": "update",
+    "type": "custom",
+    "description": "Download the latest version of the nib tool"
+  }
+]


### PR DESCRIPTION
Added a config file that contains the supported commands, their description and whether or not they are simple "wrapped" commands. With this data we can simply detect if a command like `bundle` is a wrapped command and execute `bin/wrap_command` rather than having a duplicative script for each.

This would be a good start for addressing #39.