### PR TITLE
Install yaml2json at build time for debug command

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,14 +2,11 @@
 .gitignore
 .rspec
 CONTRIBUTING.md
-Gemfile
 README.md
 release.sh
 update_docs.sh
 Dockerfile
-Gemfile.lock
 docker-compose.yml
-spec
 Dockerfile.test
 LICENSE
 docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,11 @@ FROM alpine:latest
 
 ENV COMPOSE_VERSION 1.7.1
 
+ENV YAML2JSON_VERSION 415420a6f431f7ccbbc22cde0007e3ecadc73253
+ENV YAML2JSON_URL https://github.com/bronze1man/yaml2json/blob
+ENV YAML2JSON_PATH builds/linux_amd64/yaml2json?raw=true
+ENV YAML2JSON_BIN /usr/local/bin/yaml2json
+
 RUN \
   apk add --update \
     bash \
@@ -9,7 +14,14 @@ RUN \
     jq \
     py-pip \
     py-yaml && \
-  pip install -U docker-compose==${COMPOSE_VERSION} &&\
+  apk add --update \
+    --virtual build-dependencies \
+    openssl && \
+  pip install -U docker-compose==${COMPOSE_VERSION} && \
+  wget "$YAML2JSON_URL/$YAML2JSON_VERSION/$YAML2JSON_PATH" \
+    -O "$YAML2JSON_BIN" && \
+  chmod +x "$YAML2JSON_BIN" && \
+  apk del build-dependencies && \
   rm /var/cache/apk/* && \
   rm -rf `find / -regex '.*\.py[co]' -or -name apk`
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,7 +1,13 @@
 FROM ruby:alpine
 
-ENV COMPOSE_VERSION 1.7.1
 ARG HOST_PATH
+
+ENV COMPOSE_VERSION 1.7.1
+
+ENV YAML2JSON_VERSION 415420a6f431f7ccbbc22cde0007e3ecadc73253
+ENV YAML2JSON_URL https://github.com/bronze1man/yaml2json/blob
+ENV YAML2JSON_PATH builds/linux_amd64/yaml2json?raw=true
+ENV YAML2JSON_BIN /usr/local/bin/yaml2json
 
 RUN \
   apk add --update \
@@ -11,7 +17,14 @@ RUN \
     jq \
     py-pip \
     py-yaml && \
-  pip install -U docker-compose==${COMPOSE_VERSION} &&\
+  apk add --update \
+    --virtual build-dependencies \
+    openssl && \
+  pip install -U docker-compose==${COMPOSE_VERSION} && \
+  wget "$YAML2JSON_URL/$YAML2JSON_VERSION/$YAML2JSON_PATH" \
+    -O "$YAML2JSON_BIN" && \
+  chmod +x "$YAML2JSON_BIN" && \
+  apk del build-dependencies && \
   rm /var/cache/apk/* && \
   rm -rf `find / -regex '.*\.py[co]' -or -name apk`
 

--- a/spec/localhost/yaml2json_spec.rb
+++ b/spec/localhost/yaml2json_spec.rb
@@ -1,0 +1,6 @@
+cmd = 'docker run --rm --entrypoint=ash nibdev -c "which yaml2json"'
+
+RSpec.describe command(cmd) do
+  its(:stdout) { should match(/\/usr\/local\/bin\/yaml2json/) }
+  its(:exit_status) { should eq 0 }
+end


### PR DESCRIPTION
The yaml2json library is a requirement for the debug command to work but was never added to the repo/image :blush:. This commit adds it at build time to the Docker image.