### PR TITLE
Add additional description for complex commands

### DIFF
--- a/bin/_help
+++ b/bin/_help
@@ -22,8 +22,12 @@ print_services() {
 }
 
 print_command_instructions() {
-  echo $(commands_json) | \
-    jq -r ".[] | select(.name == \"$COMMAND\") | .description"
+  template="
+    select(.name == \"$COMMAND\") |
+    \"\(.short_description)\n\n\(.long_description)\"
+  "
+
+  echo $(commands_json) | jq -r ".[] | $template"
 }
 
 show_common_help() {
@@ -51,10 +55,21 @@ check_for_updates() {
 }
 
 print_commands() {
-  template='"\(.name) \"\(.description)\" "'
+  extended_commands_json="$(
+    echo $(commands_json) | \
+      jq 'map(. + {
+        extra_help: (
+          if (.long_description) == ""
+          then ""
+          else ". See ''nib \(.name) --help'' for more detail" end
+        )
+      })'
+  )"
+
+  template='"\(.name) \"\(.short_description)\(.extra_help)\" "'
 
   echo "Commands:"
-  echo "$(echo $(commands_json) | jq -j ".[] | ${template}")" | \
+  echo "$(echo $extended_commands_json:| jq -j ".[] | ${template}")" | \
     xargs printf "  %-19s %-s\n"
 }
 

--- a/bin/_tty
+++ b/bin/_tty
@@ -4,19 +4,6 @@
 #
 #/* vim: set filetype=sh : */
 
-show_help() {
-  echo "$(print_common_usage "$COMMAND")
-
-$(print_command_instructions)
-
-Options:
-  -e, --env   Environment name (default: development)
-  -h          Print usage
-
-Services:
-$(print_services)"
-}
-
 source "/usr/local/bin/_common"
 source "/usr/local/bin/_help"
 

--- a/config/commands.json
+++ b/config/commands.json
@@ -2,71 +2,85 @@
   {
     "name": "bundle",
     "type": "wrap",
-    "description": "Run bundle for the given service"
+    "short_description": "Run bundle for the given service",
+    "long_description": ""
   },
   {
     "name": "codeclimate",
     "type": "custom",
-    "description": "Run codeclimate againt the current working directory"
+    "short_description": "Run codeclimate againt the current working directory",
+    "long_description": ""
   },
   {
     "name": "console",
     "type": "custom",
-    "description": "Start a REPL session for the given service"
+    "short_description": "Start a REPL session for the given service",
+    "long_description": "This command will try to detect the applications environment (ie. rails console or bundle console)\nand start the most appropriate REPL possible. It's possible to directly override this behaviour by\nsupplying an executable file at $pwd/bin/console."
   },
   {
     "name": "debug",
     "type": "custom",
-    "description": "Connect to a running byebug server for a given service"
+    "short_description": "Connect to a running byebug server for a given service",
+    "long_description": ""
   },
   {
     "name": "exec",
     "type": "custom",
-    "description": "Attach an interactive shell session to a running container"
+    "short_description": "Attach an interactive shell session to a running container",
+    "long_description": ""
   },
   {
     "name": "guard",
     "type": "wrap",
-    "description": "Run the guard command for the given service"
+    "short_description": "Run the guard command for the given service",
+    "long_description": ""
   },
   {
     "name": "rails",
     "type": "wrap",
-    "description": "Run the rails command for the given service"
+    "short_description": "Run the rails command for the given service",
+    "long_description": ""
   },
   {
     "name": "rake",
     "type": "wrap",
-    "description": "Run the rake command for the given service"
+    "short_description": "Run the rake command for the given service",
+    "long_description": ""
   },
   {
     "name": "rspec",
     "type": "wrap",
-    "description": "Runs the rspec command for the given service"
+    "short_description": "Runs the rspec command for the given service",
+    "long_description": ""
   },
   {
     "name": "rubocop",
     "type": "wrap",
-    "description": "Runs the rubocop command for the given service"
+    "short_description": "Runs the rubocop command for the given service",
+    "long_description": ""
   },
   {
     "name": "run",
     "type": "custom",
-    "description": "Wraps normal 'docker-compose run' to ensure that --rm is always passed"
+    "short_description": "Wraps normal 'docker-compose run' to ensure that --rm is always passed",
+    "long_description": ""
   },
   {
     "name": "setup",
     "type": "custom",
-    "description": "Runs application specific setup for the given service"
+    "short_description": "Runs application specific setup for the given service",
+    "long_description": "By default the setup command will execute 'bundle install && rake db:create db:migrate'.\n\nThis behavior can be overriden by providing an executable file in the project at $pwd/bin/setup.\nAdditionally the setup process can be augmented by providing either $pwd/bin/setup.before or\n$pwd/bin/setup.after. This allows for extending the default behavior without having to redefine it."
   },
   {
     "name": "shell",
     "type": "custom",
-    "description": "Start a shell session in a one-off service container"
+    "short_description": "Start a shell session in a one-off service container",
+    "long_description": ""
   },
   {
     "name": "update",
     "type": "custom",
-    "description": "Download the latest version of the nib tool"
+    "short_description": "Download the latest version of the nib tool",
+    "long_description": ""
   }
 ]

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,20 +1,109 @@
+
 # Supported Commands
 
 The following commands are available:
 
-Name | Description
----- | -----------
-`bundle` | Run bundle for the given service
-`codeclimate` | Run codeclimate againt the current working directory
-`console` | Start a REPL session for the given service
-`debug` | Connect to a running byebug server for a given service
-`exec` | Attach an interactive shell session to a running container
-`guard` | Run the guard command for the given service
-`rails` | Run the rails command for the given service
-`rake` | Run the rake command for the given service
-`rspec` | Runs the rspec command for the given service
-`rubocop` | Runs the rubocop command for the given service
-`run` | Wraps normal 'docker-compose run' to ensure that --rm is always passed
-`setup` | Runs application specific setup for the given service
-`shell` | Start a shell session in a one-off service container
-`update` | Download the latest version of the nib tool
+
+### `bundle`
+
+Run bundle for the given service
+
+
+
+
+### `codeclimate`
+
+Run codeclimate againt the current working directory
+
+
+
+
+### `console`
+
+Start a REPL session for the given service
+
+This command will try to detect the applications environment (ie. rails console or bundle console)
+and start the most appropriate REPL possible. It's possible to directly override this behaviour by
+supplying an executable file at $pwd/bin/console.
+
+
+### `debug`
+
+Connect to a running byebug server for a given service
+
+
+
+
+### `exec`
+
+Attach an interactive shell session to a running container
+
+
+
+
+### `guard`
+
+Run the guard command for the given service
+
+
+
+
+### `rails`
+
+Run the rails command for the given service
+
+
+
+
+### `rake`
+
+Run the rake command for the given service
+
+
+
+
+### `rspec`
+
+Runs the rspec command for the given service
+
+
+
+
+### `rubocop`
+
+Runs the rubocop command for the given service
+
+
+
+
+### `run`
+
+Wraps normal 'docker-compose run' to ensure that --rm is always passed
+
+
+
+
+### `setup`
+
+Runs application specific setup for the given service
+
+By default the setup command will execute 'bundle install && rake db:create db:migrate'.
+
+This behavior can be overriden by providing an executable file in the project at $pwd/bin/setup.
+Additionally the setup process can be augmented by providing either $pwd/bin/setup.before or
+$pwd/bin/setup.after. This allows for extending the default behavior without having to redefine it.
+
+
+### `shell`
+
+Start a shell session in a one-off service container
+
+
+
+
+### `update`
+
+Download the latest version of the nib tool
+
+
+

--- a/update_docs.sh
+++ b/update_docs.sh
@@ -1,12 +1,12 @@
 #! /bin/bash
 
-echo "# Supported Commands" > docs/commands.md
 echo "
+# Supported Commands
+
 The following commands are available:
+" > docs/commands.md
 
-Name | Description
----- | -----------" >> docs/commands.md
-
-cat config/commands.json | \
-  jq -r '.[] | "`\(.name)` | \(.description)"' \
-  >> docs/commands.md
+template='
+  .[] | "\n### `\(.name)`\n\n\(.short_description)\n\n\(.long_description)\n"
+'
+cat config/commands.json | jq -r "$template" >> docs/commands.md


### PR DESCRIPTION
Commands like `console` and `setup` support overrides and hooks. In order to make that more clear this commit adds a `.long_description` field to `./config/commands.json` and exposes that in the command specific help (ie. `nib console --help`).

After this change help for `console` and `setup` render as such:

```
❯ nibdev console --help
Usage: nib console [SERVICE]

Start a REPL session for the given service

This command will try to detect the applications environment (ie. rails console or bundle console)
and start the most appropriate REPL possible. It's possible to directly override this behaviour by
supplying an executable file at $pwd/bin/console.

Options:
  -e, --env   Environment name (default: development)
  -h          Print usage

Services:
  - app
```

```
❯ nibdev setup --help
Usage: nib setup [SERVICE]

Runs application specific setup for the given service

By default the setup command will execute 'bundle install && rake db:create db:migrate'.

This behavior can be overriden by providing an executable file in the project at $pwd/bin/setup.
Additionally the setup process can be augmented by providing either $pwd/bin/setup.before or
$pwd/bin/setup.after. This allows for extending the default behavior without having to redefine it.

Services:
  - app
```