### PR TITLE
Add options support; Pass arguments to setup binstubs.

### DIFF
--- a/bin/_common
+++ b/bin/_common
@@ -11,6 +11,10 @@ commands_json() {
   cat /usr/local/bin/config/commands.json
 }
 
+command_json() {
+  echo $(commands_json) | jq -r ".[] | select(.name == \"$COMMAND\")"
+}
+
 compose_json() {
   cat docker-compose.yml | yaml2json
 }

--- a/bin/_help
+++ b/bin/_help
@@ -7,14 +7,16 @@
 source "/usr/local/bin/_common"
 
 print_common_usage() {
-  echo "Usage: nib ${1} [SERVICE]"
+  echo "Usage: nib $COMMAND [SERVICE]"
 }
 
 print_help_options() {
-  echo "Options:
-  -h, --help      Print usage
-      --version   Print version information
-"
+  if [ "$(echo $(command_json) | jq '.options | length')" -ne 0 ]; then
+    template=".options[] | \"  \(.flag)    \(.description)\n\""
+
+    echo -e "\nOptions:"
+    echo -e "$(echo $(command_json) | jq -r "$template")\n "
+  fi
 }
 
 print_services() {
@@ -22,19 +24,16 @@ print_services() {
 }
 
 print_command_instructions() {
-  template="
-    select(.name == \"$COMMAND\") |
-    \"\(.short_description)\n\n\(.long_description)\"
-  "
+  template="\"\(.short_description)\n\n\(.long_description)\""
 
-  echo $(commands_json) | jq -r ".[] | $template"
+  echo $(command_json) | jq -r "$template"
 }
 
 show_common_help() {
-  echo "$(print_common_usage $COMMAND)
+  echo "$(print_common_usage)
 
 $(print_command_instructions)
-
+$(print_help_options)
 Services:
 $(print_services)"
 }

--- a/bin/nib
+++ b/bin/nib
@@ -7,7 +7,9 @@ show_help() {
 
 Run docker/compose commands on apps relative to the current directory
 
-$(print_help_options)
+Options:
+  -h, --help      Print usage
+      --version   Print version information
 
 $(print_commands)
 

--- a/bin/setup
+++ b/bin/setup
@@ -9,19 +9,18 @@ shift
 
 SCRIPT="
   if [ -f bin/setup.before ]; then
-    bin/setup.before
+    bin/setup.before ${@}
   fi
 
   if [ -f bin/setup ]; then
-    bin/setup
+    bin/setup ${@}
   else
     gem install bundler
     bundle install --jobs 4
-    rake db:create db:migrate
   fi
 
   if [ -f bin/setup.after ]; then
-    bin/setup.after
+    bin/setup.after ${@}
   fi
 "
 

--- a/config/commands.json
+++ b/config/commands.json
@@ -3,84 +3,98 @@
     "name": "bundle",
     "type": "wrap",
     "short_description": "Run bundle for the given service",
-    "long_description": ""
+    "long_description": "",
+    "options": []
   },
   {
     "name": "codeclimate",
     "type": "custom",
     "short_description": "Run codeclimate againt the current working directory",
-    "long_description": ""
+    "long_description": "",
+    "options": []
   },
   {
     "name": "console",
     "type": "custom",
     "short_description": "Start a REPL session for the given service",
-    "long_description": "This command will try to detect the applications environment (ie. rails console or bundle console)\nand start the most appropriate REPL possible. It's possible to directly override this behaviour by\nsupplying an executable file at $pwd/bin/console."
+    "long_description": "This command will try to detect the applications environment (ie. rails console or bundle console)\nand start the most appropriate REPL possible. It's possible to directly override this behaviour by\nsupplying an executable file at $pwd/bin/console.",
+    "options": []
   },
   {
     "name": "debug",
     "type": "custom",
     "short_description": "Connect to a running byebug server for a given service",
-    "long_description": "This command requires a little extra setup.\n\n  > The byebug server must be running inside of a web service\n   > The RUBY_DEBUG_PORT must be defined in docker-compose.yml for the service\n    > The debug port must be exposed by the service"
+    "long_description": "This command requires a little extra setup.\n\n  > The byebug server must be running inside of a web service\n   > The RUBY_DEBUG_PORT must be defined in docker-compose.yml for the service\n    > The debug port must be exposed by the service",
+    "options": []
   },
   {
     "name": "exec",
     "type": "custom",
     "short_description": "Attach an interactive shell session to a running container",
-    "long_description": ""
+    "long_description": "",
+    "options": []
   },
   {
     "name": "guard",
     "type": "wrap",
     "short_description": "Run the guard command for the given service",
-    "long_description": ""
+    "long_description": "",
+    "options": []
   },
   {
     "name": "rails",
     "type": "wrap",
     "short_description": "Run the rails command for the given service",
-    "long_description": ""
+    "long_description": "",
+    "options": []
   },
   {
     "name": "rake",
     "type": "wrap",
     "short_description": "Run the rake command for the given service",
-    "long_description": ""
+    "long_description": "",
+    "options": []
   },
   {
     "name": "rspec",
     "type": "wrap",
     "short_description": "Runs the rspec command for the given service",
-    "long_description": ""
+    "long_description": "",
+    "options": []
   },
   {
     "name": "rubocop",
     "type": "wrap",
     "short_description": "Runs the rubocop command for the given service",
-    "long_description": ""
+    "long_description": "",
+    "options": []
   },
   {
     "name": "run",
     "type": "custom",
     "short_description": "Wraps normal 'docker-compose run' to ensure that --rm is always passed",
-    "long_description": ""
+    "long_description": "",
+    "options": []
   },
   {
     "name": "setup",
     "type": "custom",
     "short_description": "Runs application specific setup for the given service",
-    "long_description": "By default the setup command will execute 'bundle install && rake db:create db:migrate'.\n\nThis behavior can be overriden by providing an executable file in the project at $pwd/bin/setup.\nAdditionally the setup process can be augmented by providing either $pwd/bin/setup.before or\n$pwd/bin/setup.after. This allows for extending the default behavior without having to redefine it."
+    "long_description": "By default the setup command will execute 'bundle install && rake db:create db:migrate'.\n\nThis behavior can be overriden by providing an executable file in the project at $pwd/bin/setup.\nAdditionally the setup process can be augmented by providing either $pwd/bin/setup.before or\n$pwd/bin/setup.after. This allows for extending the default behavior without having to redefine it.",
+    "options": []
   },
   {
     "name": "shell",
     "type": "custom",
     "short_description": "Start a shell session in a one-off service container",
-    "long_description": ""
+    "long_description": "",
+    "options": []
   },
   {
     "name": "update",
     "type": "custom",
     "short_description": "Download the latest version of the nib tool",
-    "long_description": ""
+    "long_description": "",
+    "options": []
   }
 ]


### PR DESCRIPTION
~~In addition to supporting this new option (minor)~~ (change removed) this commit adds support for defining options in configuration and having them rendered in help.

* New based on comments below:

The additional arguments to the setup command are now passed through to each of the setup scripts.