### PR TITLE
Do not expect WORKDIR /usr/src/app

### DIFF
--- a/bin/_tty
+++ b/bin/_tty
@@ -9,12 +9,10 @@ source "/usr/local/bin/_help"
 
 SERVICE="$1"
 
-local_history_path="${PWD}/tmp"
-
-mkdir -p $local_history_path
+mkdir -p "${PWD}/tmp"
 
 docker-compose run \
   --rm \
-  -e HISTFILE=/usr/src/app/tmp/shell_history \
+  -e HISTFILE=./tmp/shell_history \
   $SERVICE \
   /bin/sh -c "${SCRIPT}"

--- a/bin/console
+++ b/bin/console
@@ -4,6 +4,8 @@
 #
 #/* vim: set filetype=sh : */
 
+echo $PWD
+
 IRBRC="
 require \"rubygems\"
 require \"irb/completion\"
@@ -16,11 +18,12 @@ IRB.conf[:AUTO_INDENT] = true
 # irb history
 IRB.conf[:EVAL_HISTORY] = 10
 IRB.conf[:SAVE_HISTORY] = 1000
-IRB.conf[:HISTORY_FILE] = \"/usr/src/app/tmp/irb_history\"
+IRB.conf[:HISTORY_FILE] = \"#{Dir.pwd}/tmp/irb_history\"
 "
 
+
 PRYRC="
-Pry.config.history.file = \"/usr/src/app/tmp/irb_history\"
+Pry.config.history.file = \"#{Dir.pwd}/tmp/irb_history\"
 "
 
 SCRIPT="


### PR DESCRIPTION
Allows for applications to have a WORKDIR other than  /usr/src/app and still support shell/console history.

Resolves #78