### PR TITLE
Use Kernel.exec when delegating to compose

### DIFF
--- a/bin/nib
+++ b/bin/nib
@@ -40,7 +40,7 @@ on_error do |exception|
   case exception
   when GLI::UnknownCommand
     # delegate unknown commands over to `docker-compose`
-    system("docker-compose #{ARGV.join(' ')}")
+    exec("docker-compose #{ARGV.join(' ')}")
 
     false
   else


### PR DESCRIPTION
When we are calling compose we want to completely turn over execution
over. Kernel.exec replaces the current (Ruby) process with the executed
command.

Resolves #85
Resolves #86