### PR TITLE
Always use Kernel.exec for compose delegation

### DIFF
--- a/lib/nib/command.rb
+++ b/lib/nib/command.rb
@@ -19,7 +19,7 @@ module Nib::Command
   end
 
   def execute
-    system(script)
+    exec(script)
   end
 
   def script

--- a/spec/unit/console_spec.rb
+++ b/spec/unit/console_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Nib::Console do
 
   context 'temporary directory' do
     before do
-      allow(subject).to receive(:system).with(/docker-compose/)
+      allow(subject).to receive(:exec).with(/docker-compose/)
     end
 
     it 'is created to store history' do

--- a/spec/unit/shell_spec.rb
+++ b/spec/unit/shell_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Nib::Shell do
 
   context 'temporary directory' do
     before do
-      allow(subject).to receive(:system).with(/docker-compose/)
+      allow(subject).to receive(:exec).with(/docker-compose/)
     end
 
     it 'is created to store history' do

--- a/spec/unit/update_spec.rb
+++ b/spec/unit/update_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe Nib::Update do
   subject { described_class.new(nil, []) }
 
   before do
-    allow(subject).to receive(:system)
+    allow(subject).to receive(:exec)
   end
 
   it 'runs a docker-compose pull' do


### PR DESCRIPTION
Whenever we delegate to compose we want it to take over the process and respond to signals like SIGTERM.

This is a continuation of #87