### PR TITLE
Add support for --service-ports with `run` command

### DIFF
--- a/bin/nib
+++ b/bin/nib
@@ -149,6 +149,12 @@ desc 'Wraps normal \'docker-compose run\' to ensure that --rm is always passed'
 arg :service
 arg :command, %i(optional multiple)
 command :run do |c|
+  c.switch(
+    'service-ports',
+    negatable: false,
+    desc: 'Run command with the service\'s ports enabled and mapped to the host'
+  )
+
   c.action do |global, options, args|
     Nib::Run.execute(options, args)
   end

--- a/lib/nib/command.rb
+++ b/lib/nib/command.rb
@@ -1,21 +1,31 @@
 module Nib::Command
   def self.included(base)
     base.instance_eval do
-      attr_reader :service, :command
+      attr_reader :service, :command, :raw_options
 
       extend ClassMethods
     end
   end
 
   module ClassMethods
-    def execute(_, args)
-      new(args.shift, args.join(' ')).execute
+    def execute(raw_options, args)
+      # - first argument is (almost) always the service
+      # - pass the remaining arguments along as command
+      # - gli sends a string and symbol version of options, reduce to string
+      #   > { 'enabled' => true, :enabled => true }.map { |k, v| [k.to_s, v] }
+      #   => { 'enabled' => true }
+      new(
+        args.shift,
+        args.join(' '),
+        raw_options.map { |k, v| [k.to_s, v] }.to_h
+      ).execute
     end
   end
 
-  def initialize(service, command)
+  def initialize(service, command, raw_options = {})
     @service = service
     @command = command
+    @raw_options = raw_options
   end
 
   def execute
@@ -27,8 +37,19 @@ module Nib::Command
       docker-compose \
         run \
         --rm \
+        #{options} \
         #{service} \
         #{command}
     SCRIPT
+  end
+
+  private
+
+  def parsed_options
+    []
+  end
+
+  def options
+    parsed_options.join(' ')
   end
 end

--- a/lib/nib/run.rb
+++ b/lib/nib/run.rb
@@ -1,3 +1,13 @@
 class Nib::Run
   include Nib::Command
+
+  private
+
+  def service_ports
+    '--service-ports' if raw_options['service-ports']
+  end
+
+  def parsed_options
+    [service_ports].compact
+  end
 end

--- a/spec/unit/run_spec.rb
+++ b/spec/unit/run_spec.rb
@@ -1,8 +1,9 @@
 RSpec.describe Nib::Run do
   let(:service) { 'web' }
   let(:command) { 'puma' }
+  let(:options) { {} }
 
-  subject { described_class.new(service, command) }
+  subject { described_class.new(service, command, options) }
 
   it 'inserts the --rm arg' do
     expect(subject.script).to match(
@@ -18,5 +19,23 @@ RSpec.describe Nib::Run do
         #{command}
       /x
     )
+  end
+
+  describe 'options' do
+    context 'without service-ports' do
+      let(:options) { { 'service-ports' => false } }
+
+      it 'the service-ports flag is not included' do
+        expect(subject.script).to_not include('--service-ports')
+      end
+    end
+
+    context 'with service-ports' do
+      let(:options) { { 'service-ports' => true } }
+
+      it 'the service-ports flag is included' do
+        expect(subject.script).to include('--service-ports')
+      end
+    end
   end
 end


### PR DESCRIPTION
With [gli](https://github.com/davetron5000/gli) you can specify supported flags/switches so we can define which options we would like to support. It might be nice to just be a pass through but as I currently understand gli this might be difficult. Take `--service-ports` as the example:

```sh
> nib run --service-ports web
{ 'service-ports' => true, :'service-ports' => true} # via puts options
> nib run web
{ 'service-ports' => false, :'service-ports' => false} # via puts options
```

You might think we could then easily convert this into `--service-ports=true|false` however docker-compose expects `service-ports` to be a switch (ie. not include a value `--service-ports`). It may be possible to interrogate `ARGV` but I fear it a slippery slope.

Resolves #89