### PR TITLE
Support passing through switches for exec/run

### DIFF
--- a/bin/nib
+++ b/bin/nib
@@ -53,7 +53,7 @@ arg :service
 arg :command, %i(optional multiple)
 command :bundle do |c|
   c.action do |global, options, args|
-    Nib::Run.execute(options, args.insert(1, :bundle))
+    Nib::Run.execute(args.insert(1, :bundle))
   end
 end
 
@@ -62,7 +62,7 @@ arg :service
 arg :command, %i(optional multiple)
 command :codeclimate do |c|
   c.action do |global, options, args|
-    Nib::CodeClimate.execute(options, args)
+    Nib::CodeClimate.execute(args)
   end
 end
 
@@ -74,7 +74,7 @@ arg :service
 arg :command, %i(optional multiple)
 command :console do |c|
   c.action do |global, options, args|
-    Nib::Console.execute(options, args)
+    Nib::Console.execute(args)
   end
 end
 
@@ -87,7 +87,7 @@ long_desc 'This command requires a little extra setup.
 arg :service
 command :debug do |c|
   c.action do |global, options, args|
-    Nib::Debug.execute(options, args)
+    Nib::Debug.execute(args)
   end
 end
 
@@ -95,8 +95,10 @@ desc 'Attach an interactive shell session to a running container'
 arg :service
 arg :command, %i(optional multiple)
 command :exec do |c|
+  Nib::Options::Augmenter.augment(c)
+
   c.action do |global, options, args|
-    Nib::Exec.execute(options, args)
+    Nib::Exec.execute(args, Nib::Options::Parser.parse(options))
   end
 end
 
@@ -105,7 +107,7 @@ arg :service
 arg :command, %i(optional multiple)
 command :guard do |c|
   c.action do |global, options, args|
-    Nib::Run.execute(options, args.insert(1, :guard))
+    Nib::Run.execute(args.insert(1, :guard))
   end
 end
 
@@ -114,7 +116,7 @@ arg :service
 arg :command, %i(optional multiple)
 command :rails do |c|
   c.action do |global, options, args|
-    Nib::Run.execute(options, args.insert(1, :rails))
+    Nib::Run.execute(args.insert(1, :rails))
   end
 end
 
@@ -123,7 +125,7 @@ arg :service
 arg :command, %i(optional multiple)
 command :rake do |c|
   c.action do |global, options, args|
-    Nib::Run.execute(options, args.insert(1, :rake))
+    Nib::Run.execute(args.insert(1, :rake))
   end
 end
 
@@ -132,7 +134,7 @@ arg :service
 arg :command, %i(optional multiple)
 command :rspec do |c|
   c.action do |global, options, args|
-    Nib::Run.execute(options, args.insert(1, :rspec))
+    Nib::Run.execute(args.insert(1, :rspec))
   end
 end
 
@@ -141,7 +143,7 @@ arg :service
 arg :command, %i(optional multiple)
 command :rubocop do |c|
   c.action do |global, options, args|
-    Nib::Run.execute(options, args.insert(1, :rubocop))
+    Nib::Run.execute(args.insert(1, :rubocop))
   end
 end
 
@@ -149,8 +151,10 @@ desc 'Wraps normal \'docker-compose run\' to ensure that --rm is always passed'
 arg :service
 arg :command, %i(optional multiple)
 command :run do |c|
+  Nib::Options::Augmenter.augment(c)
+
   c.action do |global, options, args|
-    Nib::Run.execute(options, args)
+    Nib::Run.execute(args, Nib::Options::Parser.parse(options))
   end
 end
 
@@ -163,7 +167,7 @@ $pwd/bin/setup.after. This allows for extending the default behavior without hav
 arg :service
 command :setup do |c|
   c.action do |global, options, args|
-    Nib::Setup.execute(options, args)
+    Nib::Setup.execute(args)
   end
 end
 
@@ -172,14 +176,14 @@ arg :service
 arg :command, %i(optional multiple)
 command :shell do |c|
   c.action do |global, options, args|
-    Nib::Shell.execute(options, args)
+    Nib::Shell.execute(args)
   end
 end
 
 desc 'Download the latest version of the nib tool'
 command :update do |c|
   c.action do |global, options, args|
-    Nib::Update.execute(options, args)
+    Nib::Update.execute(args)
   end
 end
 

--- a/lib/core_extensions/hash.rb
+++ b/lib/core_extensions/hash.rb
@@ -1,0 +1,9 @@
+module CoreExtensions
+  module Hash
+    def symbolize_keys!
+      map { |k, v| [k.to_sym, v] }.to_h
+    end
+  end
+end
+
+Hash.include CoreExtensions::Hash

--- a/lib/nib.rb
+++ b/lib/nib.rb
@@ -1,5 +1,11 @@
 require 'nib/version'
 
+require 'core_extensions/hash'
+
+require 'nib/options'
+require 'nib/options/augmenter'
+require 'nib/options/parser'
+
 require 'nib/command'
 require 'nib/check_for_update'
 require 'nib/unrecognized_help'

--- a/lib/nib/command.rb
+++ b/lib/nib/command.rb
@@ -1,21 +1,22 @@
 module Nib::Command
   def self.included(base)
     base.instance_eval do
-      attr_reader :service, :command
+      attr_reader :service, :command, :options
 
       extend ClassMethods
     end
   end
 
   module ClassMethods
-    def execute(_, args)
-      new(args.shift, args.join(' ')).execute
+    def execute(args, options = '')
+      new(args.shift, args.join(' '), options).execute
     end
   end
 
-  def initialize(service, command)
+  def initialize(service, command, options = '')
     @service = service
     @command = command
+    @options = options
   end
 
   def execute
@@ -27,6 +28,7 @@ module Nib::Command
       docker-compose \
         run \
         --rm \
+        #{options} \
         #{service} \
         #{command}
     SCRIPT

--- a/lib/nib/exec.rb
+++ b/lib/nib/exec.rb
@@ -5,6 +5,7 @@ class Nib::Exec
     @script ||= <<~SCRIPT
       docker-compose \
         exec \
+        #{options} \
         #{service} \
         /bin/sh -c "#{entrypoint}"
     SCRIPT

--- a/lib/nib/options.rb
+++ b/lib/nib/options.rb
@@ -1,0 +1,58 @@
+module Nib::Options
+  CONFIG = [
+    {
+      names: %i(d),
+      type: :switch,
+      commands: %i(run exec),
+      options: {
+        negatable: false,
+        desc: 'Detached mode: Run container in the background, print new ' \
+          'container name.'
+      }
+    },
+    {
+      names: %i(no-deps),
+      type: :switch,
+      commands: %i(run),
+      options: {
+        negatable: false,
+        desc: 'Don\'t start linked services.'
+      }
+    },
+    {
+      names: %i(service-ports),
+      type: :switch,
+      commands: %i(run),
+      options: {
+        negatable: false,
+        desc: 'Run command with the service\'s ports enabled and mapped to ' \
+          'the host'
+      }
+    },
+    {
+      names: %i(privileged),
+      type: :switch,
+      commands: %i(exec),
+      options: {
+        negatable: false,
+        desc: 'Give extended privileges to the process.'
+      }
+    },
+    {
+      names: %i(T),
+      type: :switch,
+      commands: %i(run exec),
+      options: {
+        negatable: false,
+        desc: 'Disable pseudo-tty allocation. By default `docker-compose run`' \
+          'allocates a TTY.'
+      }
+    }
+  ].freeze
+
+  module_function
+
+  def options_for(type, name)
+    CONFIG.select { |option| option[type].include?(name) }
+  end
+end

--- a/lib/nib/options/augmenter.rb
+++ b/lib/nib/options/augmenter.rb
@@ -1,0 +1,13 @@
+module Nib::Options::Augmenter
+  module_function
+
+  def augment(command)
+    Nib::Options.options_for(:commands, command.name).each do |option|
+      command.send(
+        option[:type],
+        option[:names],
+        option[:options]
+      )
+    end
+  end
+end

--- a/lib/nib/options/parser.rb
+++ b/lib/nib/options/parser.rb
@@ -1,0 +1,11 @@
+module Nib::Options::Parser
+  module_function
+
+  def parse(raw_options)
+    raw_options.symbolize_keys!.map do |name, enabled|
+      next unless enabled
+
+      name.length == 1 ? "-#{name}" : "--#{name}"
+    end.compact.join(' ')
+  end
+end

--- a/spec/unit/options/augmenter_spec.rb
+++ b/spec/unit/options/augmenter_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe Nib::Options::Augmenter do
+  let(:command_name) { :run }
+  let(:command)      { double('command', name: command_name) }
+
+  subject { described_class }
+
+  it 'adds switches to a command' do
+    expect(command).to receive(:switch).at_least(1)
+
+    subject.augment(command)
+  end
+end

--- a/spec/unit/options/parser_spec.rb
+++ b/spec/unit/options/parser_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe Nib::Options::Parser do
+  let(:raw_options) do
+    {
+      'd'              => true,
+      :d               => true,
+      'no-deps'        => false,
+      :'no-deps'       => false,
+      'service-ports'  => true,
+      :'service-ports' => true
+    }
+  end
+
+  subject { described_class }
+
+  it 'returns a list of enabled switches' do
+    expect(subject.parse(raw_options)).to eq('-d --service-ports')
+  end
+end

--- a/spec/unit/options_spec.rb
+++ b/spec/unit/options_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe Nib::Options do
+  subject { described_class }
+
+  it 'finds options by name' do
+    options = subject.options_for(:names, :'service-ports')
+
+    options.each do |option|
+      expect(option[:names]).to include(:'service-ports')
+    end
+  end
+
+  it 'finds options for commands by name' do
+    options = subject.options_for(:commands, :run)
+
+    options.each do |option|
+      expect(option[:commands]).to include(:run)
+    end
+  end
+end


### PR DESCRIPTION
Prior to this implementation something like the following was not possible:

```sh
nib run --service-ports web puma
```

These changes add support for accepting some options (switches) for the `run` and `exec` commands specifically.

Resolves #89