### PR TITLE
Viva the `--no-deps` switch

### DIFF
--- a/bin/nib
+++ b/bin/nib
@@ -53,7 +53,7 @@ arg :service
 arg :command, %i(optional multiple)
 command :bundle do |c|
   c.action do |global, options, args|
-    Nib::Run.execute(args.insert(1, :bundle))
+    Nib::Run.execute(args.insert(1, :bundle), '--no-deps')
   end
 end
 
@@ -62,7 +62,7 @@ arg :service
 arg :command, %i(optional multiple)
 command :codeclimate do |c|
   c.action do |global, options, args|
-    Nib::CodeClimate.execute(args)
+    Nib::CodeClimate.execute(args, '--no-deps')
   end
 end
 
@@ -87,7 +87,7 @@ long_desc 'This command requires a little extra setup.
 arg :service
 command :debug do |c|
   c.action do |global, options, args|
-    Nib::Debug.execute(args)
+    Nib::Debug.execute(args, '--no-deps')
   end
 end
 
@@ -143,7 +143,7 @@ arg :service
 arg :command, %i(optional multiple)
 command :rubocop do |c|
   c.action do |global, options, args|
-    Nib::Run.execute(args.insert(1, :rubocop))
+    Nib::Run.execute(args.insert(1, :rubocop), '--no-deps')
   end
 end
 

--- a/lib/nib/code_climate.rb
+++ b/lib/nib/code_climate.rb
@@ -3,11 +3,11 @@ require 'tempfile'
 class Nib::CodeClimate
   include Nib::Command
 
-  def self.execute(args)
+  def self.execute(args, options = '')
     # Discard service name because codeclimate is run on local path
     args.shift
 
-    new(nil, args.join(' ')).execute
+    new(nil, args.join(' '), options).execute
   end
 
   def script

--- a/lib/nib/debug.rb
+++ b/lib/nib/debug.rb
@@ -11,17 +11,6 @@ class Nib::Debug
     super
   end
 
-  def script
-    @script ||= <<~SCRIPT
-      docker-compose \
-        run \
-        --rm \
-        --no-deps \
-        #{service} \
-        #{command}
-    SCRIPT
-  end
-
   private
 
   def command

--- a/spec/unit/debug_spec.rb
+++ b/spec/unit/debug_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Nib::Debug do
   let(:service) { 'web' }
 
-  subject { described_class.new(service, nil) }
+  subject { described_class.new(service, nil, '--no-deps') }
 
   before do
     allow(subject).to receive(:compose_file) do


### PR DESCRIPTION
This change was [previously made](https://github.com/technekes/nib/commit/abfd9e33e9ee24eb954704aeffd86095ecc5b4c5) however was lost in the transition from bash to Ruby.

Resolves #74