### PR TITLE
Support passing through flags for exec/run

### DIFF
--- a/lib/nib/options.rb
+++ b/lib/nib/options.rb
@@ -3,7 +3,7 @@ module Nib::Options
     {
       names: %i(d),
       type: :switch,
-      commands: %i(run exec),
+      commands: %i(exec run),
       options: {
         negatable: false,
         desc: 'Detached mode: Run container in the background, print new ' \
@@ -41,11 +41,89 @@ module Nib::Options
     {
       names: %i(T),
       type: :switch,
-      commands: %i(run exec),
+      commands: %i(exec run),
       options: {
         negatable: false,
-        desc: 'Disable pseudo-tty allocation. By default `docker-compose run`' \
-          'allocates a TTY.'
+        desc: 'Disable pseudo-tty allocation. By default `docker-compose ' \
+          'run` allocates a TTY.'
+      }
+    },
+    {
+      names: %i(name),
+      type: :flag,
+      commands: %i(run),
+      options: {
+        arg_name: 'NAME',
+        desc: 'Assign a name to the container',
+        multiple: false,
+        type: String
+      }
+    },
+    {
+      names: %i(entrypoint),
+      type: :flag,
+      commands: %i(run),
+      options: {
+        arg_name: 'CMD',
+        desc: 'Override the entrypoint of the image.',
+        multiple: false,
+        type: String
+      }
+    },
+    {
+      names: %i(e),
+      type: :flag,
+      commands: %i(run),
+      options: {
+        arg_name: 'KEY=VAL',
+        desc: 'Set an environment variable',
+        multiple: true,
+        type: String
+      }
+    },
+    {
+      names: %i(u user),
+      type: :flag,
+      commands: %i(exec run),
+      options: {
+        arg_name: '""',
+        desc: 'Run as specified username or uid',
+        multiple: false,
+        type: String
+      }
+    },
+    {
+      names: %i(p publish),
+      type: :flag,
+      commands: %i(run),
+      options: {
+        arg_name: '[]',
+        desc: 'Publish a container\'s port(s) to the host',
+        multiple: false,
+        type: Array
+      }
+    },
+    {
+      names: %i(workdir),
+      type: :flag,
+      commands: %i(run),
+      options: {
+        arg_name: '""',
+        desc: 'Working directory inside the container',
+        multiple: false,
+        type: String
+      }
+    },
+    {
+      names: %i(index),
+      type: :flag,
+      commands: %i(exec),
+      options: {
+        arg_name: 'index',
+        desc: 'index of the container if there are multiple instances of a ' \
+          'service [default: 1]',
+        multiple: false,
+        type: String
       }
     }
   ].freeze

--- a/lib/nib/options/parser.rb
+++ b/lib/nib/options/parser.rb
@@ -2,10 +2,26 @@ module Nib::Options::Parser
   module_function
 
   def parse(raw_options)
-    raw_options.symbolize_keys!.map do |name, enabled|
-      next unless enabled
+    raw_options.symbolize_keys!.map do |name, value|
+      option = Nib::Options.options_for(:names, name).first
 
-      name.length == 1 ? "-#{name}" : "--#{name}"
+      send("parse_#{option[:type]}", name, value)
     end.compact.join(' ')
+  end
+
+  def parse_switch(name, enabled)
+    return unless enabled
+
+    flag_for(name)
+  end
+
+  def parse_flag(name, values)
+    Array(values).map do |value|
+      "#{flag_for(name)} #{value}"
+    end
+  end
+
+  def flag_for(name)
+    name.length == 1 ? "-#{name}" : "--#{name}"
   end
 end

--- a/spec/unit/options/augmenter_spec.rb
+++ b/spec/unit/options/augmenter_spec.rb
@@ -5,7 +5,15 @@ RSpec.describe Nib::Options::Augmenter do
   subject { described_class }
 
   it 'adds switches to a command' do
+    allow(command).to receive(:flag).at_least(1)
     expect(command).to receive(:switch).at_least(1)
+
+    subject.augment(command)
+  end
+
+  it 'adds flags to a command' do
+    allow(command).to receive(:switch).at_least(1)
+    expect(command).to receive(:flag).at_least(1)
 
     subject.augment(command)
   end

--- a/spec/unit/options/parser_spec.rb
+++ b/spec/unit/options/parser_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Nib::Options::Parser do
-  let(:raw_options) do
+  let(:switch_options) do
     {
       'd'              => true,
       :d               => true,
@@ -10,9 +10,30 @@ RSpec.describe Nib::Options::Parser do
     }
   end
 
+  let(:flag_options) do
+    {
+      'name'           => 'banana',
+      :name            => 'banana',
+      'e'              => %i(FOO=bar RAILS_ENV=development),
+      :e               => %i(FOO=bar RAILS_ENV=development),
+      'entrypoint'     => '/sh',
+      :entrypoint      => '/sh'
+    }
+  end
+
   subject { described_class }
 
-  it 'returns a list of enabled switches' do
-    expect(subject.parse(raw_options)).to eq('-d --service-ports')
+  context 'switches' do
+    it 'returns a list of enabled switches' do
+      expect(subject.parse(switch_options)).to eq('-d --service-ports')
+    end
+  end
+
+  context 'flags' do
+    it 'returns a list of flags with their values' do
+      expect(subject.parse(flag_options)).to eq(
+        '--name banana -e FOO=bar -e RAILS_ENV=development --entrypoint /sh'
+      )
+    end
   end
 end


### PR DESCRIPTION
Prior to this implementation something like the following was not possible:

```sh
nib run -e RAILS_ENV=production web puma
```

These changes add support for accepting the remaining options (flags) for the `exec` and `run` commands specifically.

Help output for `exec` and `run` now looks like this:

```sh
❯ nibdev exec --help
NAME
    exec - Attach an interactive shell session to a running container

SYNOPSIS
    nib [global options] exec [command options] service [command][, [command]]*

COMMAND OPTIONS
    -T            - Disable pseudo-tty allocation. By default `docker-compose run` allocates a TTY.
    -d            - Detached mode: Run container in the background, print new container name.
    --index=index - index of the container if there are multiple instances of a service [default: 1] (default: none)
    --privileged  - Give extended privileges to the process.
    -u, --user="" - Run as specified username or uid (default: none)
```

```sh
❯ nibdev run --help
NAME
    run - Wraps normal 'docker-compose run' to ensure that --rm is always passed

SYNOPSIS
    nib [global options] run [command options] service [command][, [command]]*

COMMAND OPTIONS
    -T               - Disable pseudo-tty allocation. By default `docker-compose run` allocates a TTY.
    -d               - Detached mode: Run container in the background, print new container name.
    -e KEY=VAL       - Set an environment variable (may be used more than once, default: none)
    --entrypoint=CMD - Override the entrypoint of the image. (default: none)
    --name=NAME      - Assign a name to the container (default: none)
    --no-deps        - Don’t start linked services.
    -p, --publish=[] - Publish a container’s port(s) to the host (default: none)
    --service-ports  - Run command with the service’s ports enabled and mapped to the host
    -u, --user=""    - Run as specified username or uid (default: none)
    --workdir=""     - Working directory inside the container (default: none)
```
