### PR TITLE
Feature/adds dbconsole command

### DIFF
--- a/bin/nib
+++ b/bin/nib
@@ -78,6 +78,22 @@ command :console do |c|
   end
 end
 
+desc 'Start a Database REPL session for the given service'
+long_desc <<-"DESC"
+  This command, for now, will simply run the file supplied at $pwd/bin/dbconsole.
+  We recommend someting as simple as:
+
+  #! /bin/sh\n
+  psql "$@"
+DESC
+arg :service
+arg :command, %i(optional multiple)
+command :dbconsole do |c|
+  c.action do |global, options, args|
+    Nib::Run.execute(args.insert(1, './bin/dbconsole'))
+  end
+end
+
 desc 'Connect to a running byebug server for a given service'
 long_desc 'This command requires a little extra setup.
 

--- a/spec/dummy/rails/bin/dbconsole
+++ b/spec/dummy/rails/bin/dbconsole
@@ -1,0 +1,3 @@
+#! /bin/sh
+
+echo 'Running psql (or some other db repl)'

--- a/spec/integration/dbconsole_spec.rb
+++ b/spec/integration/dbconsole_spec.rb
@@ -1,0 +1,4 @@
+RSpec.describe command('cd spec/dummy/rails && nibtest dbconsole web') do
+  its(:stdout) { should match(/psql/) }
+  its(:exit_status) { should eq 0 }
+end

--- a/spec/unit/dbconsole_spec.rb
+++ b/spec/unit/dbconsole_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe 'dbconsole' do
+  let(:service) { 'web' }
+  let(:command) { './bin/dbconsole -c \'SELECT * FROM foo;\'' }
+
+  subject { Nib::Run.new(service, command) }
+
+  it 'executes ./bin/dbconsole' do
+    expect(subject.script).to match(
+      %r{
+        docker-compose
+        .*
+        run
+        .*
+        --rm
+        .*
+        #{service}
+        .*
+        \./bin/dbconsole\s-c\s'SELECT\s\*\sFROM\sfoo;'
+      }x
+    )
+  end
+end


### PR DESCRIPTION
Enables `nib` to simply run a script, located at `$pwd/bin/dbconsole` with the intention of launching a database REPL console, such as `psql` in the context of the service.