### PR TITLE
Add support for `-f` flag

### DIFF
--- a/bin/nib
+++ b/bin/nib
@@ -16,6 +16,13 @@ preserve_argv true
 
 GLI::Commands::Help.skips_post = false
 
+flag(
+  %i(f file),
+  arg_name: 'FILE',
+  desc: 'Specify an alternate compose file',
+  default_value: 'docker-compose.yml'
+)
+
 pre do |global, command, options, args|
   # Pre logic here
   # Return true to proceed; false to abort and not call the


### PR DESCRIPTION
This will allow for passing alternative config to delegated commands:

```sh
nib -f docker-compose.alt.yml up
```

This change does not allow for `-f` to be passed to "native" `nib`
commands (`shell`, `console` etc.)