### PR TITLE
Re-enable CodeClimate coverage reporting

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,6 +17,10 @@ begin
     end
   end
 
+  task :report_coverage do
+    `CI_COMMITED_AT=$CI_TIMESTAMP codeclimate-test-reporter`
+  end
+
   task spec: %w(rspec:unit rspec:integration)
   task default: %i(spec)
 rescue LoadError # rubocop:disable Lint/HandleExceptions

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -1,11 +1,18 @@
-- type: parallel
+- type: serial
   steps:
-    - name: rubocop
-      service: gem
-      command: rubocop -D
-    - name: unit specs
-      service: gem
-      command: rake rspec:unit
-    # - name: integration specs
-    #   service: gem
-    #   command: rake rspec:integration
+  - type: parallel
+    steps:
+      - name: rubocop
+        service: gem
+        command: rubocop -D
+      - name: unit specs
+        service: gem
+        command: rake rspec:unit
+      # - name: integration specs
+      #   service: gem
+      #   command: rake rspec:integration
+  - type: serial
+    steps:
+      - name: report coverate
+        service: gem
+        command: rake report_coverage

--- a/nib.gemspec
+++ b/nib.gemspec
@@ -26,5 +26,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency('guard')
   s.add_development_dependency('guard-rspec')
   s.add_development_dependency('guard-rubocop')
-  s.add_development_dependency('codeclimate-test-reporter')
+  s.add_development_dependency('simplecov')
+  s.add_development_dependency('codeclimate-test-reporter', '~> 1.0.5')
 end


### PR DESCRIPTION
There were some difficulties with the CodeClimate gem running on Codeship which previously required a patch. v1.0.5 of the gem should resolve this issue.