### PR TITLE
Allow `--no-deps` on `run` to behave as expected

### DIFF
--- a/bin/nib
+++ b/bin/nib
@@ -161,6 +161,9 @@ command :run do |c|
   Nib::Options::Augmenter.augment(c)
 
   c.action do |global, options, args|
+    # work around an `OptionParser` limitation: https://git.io/vDKrh
+    options[:'no-deps'] = options['no-deps'] = ARGV.include?('--no-deps')
+
     Nib::Run.execute(args, Nib::Options::Parser.parse(options))
   end
 end


### PR DESCRIPTION
Prior to this change whether the `--no-deps` flag was specified or not it was always evaluated by `gli` to be `false` and therefor never sent on to `docker-compose`. For more details on why, have a look at this issue report on `gli`. https://github.com/davetron5000/gli/pull/90

Resolves #97