### PR TITLE
Make history more universal

### DIFF
--- a/lib/nib.rb
+++ b/lib/nib.rb
@@ -7,6 +7,7 @@ require 'nib/options/augmenter'
 require 'nib/options/parser'
 
 require 'nib/command'
+require 'nib/history'
 require 'nib/check_for_update'
 require 'nib/unrecognized_help'
 require 'nib/code_climate'

--- a/lib/nib/console.rb
+++ b/lib/nib/console.rb
@@ -1,24 +1,8 @@
 class Nib::Console
   include Nib::Command
-
-  IRBRC = <<~'IRB'.freeze
-    require \"rubygems\"
-    require \"irb/completion\"
-    require \"irb/ext/save-history\"
-    # irb configuration
-    IRB.conf[:PROMPT_MODE] = :SIMPLE
-    IRB.conf[:AUTO_INDENT] = true
-    # irb history
-    IRB.conf[:EVAL_HISTORY] = 10
-    IRB.conf[:SAVE_HISTORY] = 1000
-    IRB.conf[:HISTORY_FILE] = \"#{Dir.pwd}/tmp/irb_history\"
-  IRB
-
-  PRYRC = 'Pry.config.history.file = \"#{Dir.pwd}/tmp/irb_history\"'.freeze
+  prepend Nib::History
 
   SCRIPT = <<~SH.freeze
-    echo '#{IRBRC}' > /root/.irbrc
-    echo '#{PRYRC}' > /root/.pryrc
     has_pry=false
     has_boot=false
     if hash pry 2>/dev/null ; then
@@ -43,25 +27,9 @@ class Nib::Console
     fi
   SH
 
-  def execute
-    system('mkdir', '-p', './tmp')
-    super
-  end
-
-  def script
-    @script ||= <<~SCRIPT
-      docker-compose \
-        run \
-        --rm \
-        -e HISTFILE=./tmp/shell_history \
-        #{service} \
-        #{command}
-    SCRIPT
-  end
-
   private
 
   def command
-    "/bin/sh -c \"#{SCRIPT}\""
+    SCRIPT
   end
 end

--- a/lib/nib/exec.rb
+++ b/lib/nib/exec.rb
@@ -1,5 +1,6 @@
 class Nib::Exec
   include Nib::Command
+  prepend Nib::History
 
   def script
     @script ||= <<~SCRIPT
@@ -7,15 +8,15 @@ class Nib::Exec
         exec \
         #{options} \
         #{service} \
-        /bin/sh -c "#{entrypoint}"
+        #{command}
     SCRIPT
   end
 
   def action
-    command.to_s.empty? ? '' : "-c '#{command}'"
+    @command.to_s.empty? ? '' : "-c '#{@command}'"
   end
 
-  def entrypoint
+  def command
     "
       if hash bash 2>/dev/null ; then
         bash #{action}

--- a/lib/nib/history.rb
+++ b/lib/nib/history.rb
@@ -1,0 +1,32 @@
+module Nib::History
+  IRBRC = <<~'IRB'.freeze
+    require \"rubygems\"
+    require \"irb/completion\"
+    require \"irb/ext/save-history\"
+    # irb configuration
+    IRB.conf[:PROMPT_MODE] = :SIMPLE
+    IRB.conf[:AUTO_INDENT] = true
+    # irb history
+    IRB.conf[:EVAL_HISTORY] = 10
+    IRB.conf[:SAVE_HISTORY] = 1000
+    IRB.conf[:HISTORY_FILE] = \"#{Dir.pwd}/tmp/irb_history\"
+  IRB
+
+  PRYRC = 'Pry.config.history.file = \"#{Dir.pwd}/tmp/irb_history\"'.freeze
+
+  def execute
+    system('mkdir', '-p', './tmp')
+    super
+  end
+
+  def command
+    <<~COMMAND
+      /bin/sh -c \"
+        export HISTFILE=./tmp/shell_history
+        echo '#{IRBRC}' > /root/.irbrc
+        echo '#{PRYRC}' > /root/.pryrc
+        #{super}
+      \"
+    COMMAND
+  end
+end

--- a/lib/nib/run.rb
+++ b/lib/nib/run.rb
@@ -1,3 +1,4 @@
 class Nib::Run
   include Nib::Command
+  prepend Nib::History
 end

--- a/lib/nib/shell.rb
+++ b/lib/nib/shell.rb
@@ -1,5 +1,6 @@
 class Nib::Shell
   include Nib::Command
+  prepend Nib::History
 
   SCRIPT = <<~SH.freeze
     if hash bash 2>/dev/null ; then
@@ -11,25 +12,9 @@ class Nib::Shell
     fi
   SH
 
-  def execute
-    system('mkdir', '-p', './tmp')
-    super
-  end
-
-  def script
-    @script ||= <<~SCRIPT
-      docker-compose \
-        run \
-        --rm \
-        -e HISTFILE=./tmp/shell_history \
-        #{service} \
-        #{command}
-    SCRIPT
-  end
-
   private
 
   def command
-    "/bin/sh -c \"#{SCRIPT}\""
+    SCRIPT
   end
 end

--- a/spec/unit/console_spec.rb
+++ b/spec/unit/console_spec.rb
@@ -25,8 +25,6 @@ RSpec.describe Nib::Console do
           .*
           --rm
           .*
-          -e\sHISTFILE=./tmp/shell_history
-          .*
           #{service}
           .*
           /bin/sh\s-c

--- a/spec/unit/run_spec.rb
+++ b/spec/unit/run_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe Nib::Run do
         --rm
         .*
         #{service}
-        .*
-        #{command}
+        (.|\n)*
+        #{command}$
       /x
     )
   end

--- a/spec/unit/shell_spec.rb
+++ b/spec/unit/shell_spec.rb
@@ -25,8 +25,6 @@ RSpec.describe Nib::Shell do
           .*
           --rm
           .*
-          -e\sHISTFILE=./tmp/shell_history
-          .*
           #{service}
           .*
           /bin/sh\s-c


### PR DESCRIPTION
Previously the shell and console command set up "shell history" and the console command setup "irb/pry history". However, if you were to execute the shell command and then `> pry` the pry history would not be wired up. With this change any interactive session is prepped with all history types configured.

Resolves #100