### PR TITLE
Report test coverage in spec container

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,10 +17,6 @@ begin
     end
   end
 
-  task :report_coverage do
-    `CI_COMMITED_AT=$CI_TIMESTAMP codeclimate-test-reporter`
-  end
-
   task spec: %w(rspec:unit rspec:integration)
   task default: %i(spec)
 rescue LoadError # rubocop:disable Lint/HandleExceptions

--- a/bin/ci
+++ b/bin/ci
@@ -1,0 +1,10 @@
+#! /bin/bash
+
+set -e
+
+# https://git.io/vDywe
+export CI_COMMITED_AT=$CI_TIMESTAMP
+
+rake rspec:unit
+# rake rspec:integration
+codeclimate-test-reporter

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -7,12 +7,4 @@
         command: rubocop -D
       - name: unit specs
         service: gem
-        command: rake rspec:unit
-      # - name: integration specs
-      #   service: gem
-      #   command: rake rspec:integration
-  - type: serial
-    steps:
-      - name: report coverate
-        service: gem
-        command: rake report_coverage
+        command: bin/ci


### PR DESCRIPTION
Test coverage reporting has not been working. Having reviewed the output on Codeship it would appear that the reporter is running in a container other than then the container that generates the coverage. This change ensure they are run together.