### PR TITLE
Support prior versions or Ruby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Your contribution here.
 
+* [#120](https://github.com/technekes/nib/pull/120) Support prior versions or Ruby - [@johnallen3d](https://github.com/johnallen3d).
+
 # 1.4.0 (2017-02-15)
 
 ### Features

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby
+FROM ruby:2.2
 
 ENV COMPOSE_VERSION 1.10.0
 

--- a/bin/update_docs
+++ b/bin/update_docs
@@ -2,7 +2,7 @@
 
 require 'json'
 
-header = <<~'HEADER'
+header = <<-'HEADER'
   # Supported Commands
 
   The following commands are available:

--- a/lib/nib/check_for_update.rb
+++ b/lib/nib/check_for_update.rb
@@ -4,7 +4,7 @@ class Nib::CheckForUpdate
   def self.execute(_, _)
     return if installed == latest
 
-    puts <<~MESSAGE
+    puts <<-MESSAGE
 
     An update is available for nib: #{latest}
     Use 'nib update' to install the latest version

--- a/lib/nib/code_climate.rb
+++ b/lib/nib/code_climate.rb
@@ -11,7 +11,7 @@ class Nib::CodeClimate
   end
 
   def script
-    @script ||= <<~SCRIPT
+    @script ||= <<-SCRIPT
       docker-compose \
         -f #{compose_file.path} \
         run \

--- a/lib/nib/command.rb
+++ b/lib/nib/command.rb
@@ -24,7 +24,7 @@ module Nib::Command
   end
 
   def script
-    @script ||= <<~SCRIPT
+    @script ||= <<-SCRIPT
       docker-compose \
         run \
         --rm \

--- a/lib/nib/console.rb
+++ b/lib/nib/console.rb
@@ -2,7 +2,7 @@ class Nib::Console
   include Nib::Command
   prepend Nib::History
 
-  SCRIPT = <<~SH.freeze
+  SCRIPT = <<-SH.freeze
     has_pry=false
     has_boot=false
     if hash pry 2>/dev/null ; then

--- a/lib/nib/debug.rb
+++ b/lib/nib/debug.rb
@@ -38,6 +38,6 @@ class Nib::Debug
       (?<port>\d+)    # capture numeric value of the port
     /x
 
-    compose_file.match(regexp)&.send(:[], :port)
+    (compose_file.match(regexp) || {}).send(:[], :port)
   end
 end

--- a/lib/nib/exec.rb
+++ b/lib/nib/exec.rb
@@ -3,7 +3,7 @@ class Nib::Exec
   prepend Nib::History
 
   def script
-    @script ||= <<~SCRIPT
+    @script ||= <<-SCRIPT
       docker-compose \
         exec \
         #{options} \

--- a/lib/nib/history.rb
+++ b/lib/nib/history.rb
@@ -1,5 +1,5 @@
 module Nib::History
-  IRBRC = <<~'IRB'.freeze
+  IRBRC = <<-'IRB'.freeze
     require \"rubygems\"
     require \"irb/completion\"
     require \"irb/ext/save-history\"
@@ -20,7 +20,7 @@ module Nib::History
   end
 
   def command
-    <<~COMMAND
+    <<-COMMAND
       /bin/sh -c \"
         export HISTFILE=./tmp/shell_history
         echo '#{IRBRC}' > /root/.irbrc

--- a/lib/nib/setup.rb
+++ b/lib/nib/setup.rb
@@ -1,7 +1,7 @@
 class Nib::Setup
   include Nib::Command
 
-  SCRIPT = <<~SH.freeze
+  SCRIPT = <<-SH.freeze
     if [ -f bin/setup.before ]; then
       bin/setup.before
     fi

--- a/lib/nib/shell.rb
+++ b/lib/nib/shell.rb
@@ -2,7 +2,7 @@ class Nib::Shell
   include Nib::Command
   prepend Nib::History
 
-  SCRIPT = <<~SH.freeze
+  SCRIPT = <<-SH.freeze
     if hash bash 2>/dev/null ; then
       bash
     elif hash ash 2>/dev/null ; then

--- a/lib/nib/unrecognized_help.rb
+++ b/lib/nib/unrecognized_help.rb
@@ -1,6 +1,6 @@
 class Nib::UnrecognizedHelp
   def self.execute(_, _)
-    puts <<~MESSAGE
+    puts <<-MESSAGE
 
       Note:
         Unrecognized commands will be delegated to docker-compose.

--- a/nib.gemspec
+++ b/nib.gemspec
@@ -9,9 +9,11 @@ Gem::Specification.new do |s|
   s.platform = Gem::Platform::RUBY
   s.summary = 'The tip of the pen (compose)'
 
-  s.description = <<~'DESCRIPTION'
+  s.description = <<-'DESCRIPTION'
     nib is a docker-compose wrapper geared towards Ruby/Rails development.
   DESCRIPTION
+
+  s.required_ruby_version = '>= 2.2.0'
 
   s.files = Dir['lib/**/*.rb'] | Dir['config/**/*'] | ['VERSION']
   s.require_paths << 'lib'

--- a/spec/unit/debug_spec.rb
+++ b/spec/unit/debug_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Nib::Debug do
     it 'runs a container with bybug on the appropriate port' do
       expect(subject.script).to match(
         /
-          ^docker-compose
+          docker-compose
           .*
           run
           .*


### PR DESCRIPTION
Removes syntax sugar usage introduced since Ruby version 2.2

Resolves #118