### PR TITLE
Use a Docker volume to store history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#123](https://github.com/technekes/nib/pull/123) Favor Docker over Compose for CodeClimate command - [@johnallen3d](https://github.com/johnallen3d).
 * [#129](https://github.com/technekes/nib/pull/129) Upgrade `shell` command - [@johnallen3d](https://github.com/johnallen3d).
 * [#130](https://github.com/technekes/nib/pull/130) Use CMD if argument not passed to `run` - [@johnallen3d](https://github.com/johnallen3d).
+* [#124](https://github.com/technekes/nib/pull/124) Use a Docker volume to store history - [@johnallen3d](https://github.com/johnallen3d).
 
 # 1.4.2 (2017-02-23)
 

--- a/lib/nib.rb
+++ b/lib/nib.rb
@@ -8,6 +8,8 @@ require 'nib/options/parser'
 
 require 'nib/command'
 require 'nib/history'
+require 'nib/history/compose'
+require 'nib/history/config'
 require 'nib/check_for_update'
 require 'nib/unrecognized_help'
 require 'nib/code_climate'

--- a/lib/nib/code_climate.rb
+++ b/lib/nib/code_climate.rb
@@ -1,5 +1,3 @@
-require 'tempfile'
-
 class Nib::CodeClimate
   include Nib::Command
 

--- a/lib/nib/command.rb
+++ b/lib/nib/command.rb
@@ -26,6 +26,7 @@ module Nib::Command
   def script
     @script ||= <<-SCRIPT
       docker-compose \
+        #{alternate_compose_file} \
         run \
         --rm \
         #{options} \
@@ -33,4 +34,6 @@ module Nib::Command
         #{command}
     SCRIPT
   end
+
+  def alternate_compose_file; end
 end

--- a/lib/nib/history/compose.rb
+++ b/lib/nib/history/compose.rb
@@ -1,0 +1,95 @@
+require 'tempfile'
+require 'tmpdir'
+
+class Nib::History::Compose
+  attr_reader :dir, :volume_name
+
+  def initialize
+    @volume_name = 'nib_history'
+    @dir = "#{Dir.tmpdir}/#{Dir.pwd.split('/').last}"
+
+    FileUtils.mkdir_p(dir)
+  end
+
+  def path
+    file.path
+  end
+
+  def config
+    original_config
+      .merge('services' => services_config)
+      .merge('volumes' => volumes_config)
+  end
+
+  private
+
+  def original_config
+    @original_config ||= YAML.safe_load(`docker-compose config`)
+  end
+
+  def file
+    @file ||= Tempfile.open('compose', dir) do |compose|
+      compose.write(config.to_yaml)
+      compose
+    end
+  end
+
+  def services_config
+    Services.new(volume_name, original_config['services']).config
+  end
+
+  def volumes_config
+    Volumes.new(volume_name, original_config['volumes']).config
+  end
+
+  class Services
+    attr_reader :original_config, :volume_name
+
+    def initialize(volume_name, original_config)
+      @original_config = original_config
+      @volume_name = volume_name
+    end
+
+    def config
+      original_config.each_with_object({}) do |(name, definition), extended|
+        extended[name] = Service.new(volume_name, definition).config
+      end
+    end
+  end
+
+  class Service
+    attr_reader :original_config, :volume_name
+
+    def initialize(volume_name, original_config)
+      @original_config = original_config
+      @volume_name = volume_name
+    end
+
+    def config
+      original_config.merge('volumes' => volumes_config << history_config)
+    end
+
+    private
+
+    def volumes_config
+      original_config['volumes'] || []
+    end
+
+    def history_config
+      "#{volume_name}:#{Nib::History::PATH}"
+    end
+  end
+
+  class Volumes
+    attr_reader :original_config, :volume_name
+
+    def initialize(volume_name, original_config = nil)
+      @original_config = original_config || {}
+      @volume_name = volume_name
+    end
+
+    def config
+      original_config.merge(volume_name => nil)
+    end
+  end
+end

--- a/lib/nib/history/config.rb
+++ b/lib/nib/history/config.rb
@@ -1,0 +1,35 @@
+require 'fileutils'
+
+class Nib::History::Config
+  attr_reader :type, :history_command, :host_path
+
+  def initialize(type, history_command)
+    @type = type
+    @history_command = history_command
+    @host_path = "#{ENV['HOME']}/.#{type}"
+
+    FileUtils.mkdir_p './tmp'
+  end
+
+  def container_path
+    config_file.path
+  end
+
+  private
+
+  def config
+    if File.exist?(host_path)
+      File.read(host_path)
+    else
+      Nib.load_default_config(:shell, type)
+    end
+  end
+
+  def config_file
+    @config_file ||= File.open("./tmp/#{type}", 'w+') do |file|
+      file.write(config)
+      file.write(history_command + "\n")
+      file
+    end
+  end
+end

--- a/spec/fixtures/compose/with_existing_volumes_key.yml
+++ b/spec/fixtures/compose/with_existing_volumes_key.yml
@@ -1,0 +1,15 @@
+networks: {}
+services:
+  redis:
+    image: redis:alpine
+    network_mode: bridge
+    ports:
+    - 6379:6379
+  web:
+    build:
+      context: /dev/nib
+    network_mode: bridge
+    volumes:
+    - /dev/nib:/usr/src/app:rw
+version: '2.1'
+volumes: {}

--- a/spec/fixtures/compose/without_existing_volumes_key.yml
+++ b/spec/fixtures/compose/without_existing_volumes_key.yml
@@ -1,0 +1,13 @@
+networks: {}
+services:
+  redis:
+    image: redis:alpine
+    network_mode: bridge
+    ports:
+    - 6379:6379
+  web:
+    build:
+      context: /dev/nib
+    network_mode: bridge
+version: '2.1'
+volumes: {}

--- a/spec/support/setup.rb
+++ b/spec/support/setup.rb
@@ -1,0 +1,11 @@
+DEFAULT_COMPOSE = YAML.load_file(
+  'spec/fixtures/compose/with_existing_volumes_key.yml'
+)
+
+RSpec.configure do |config|
+  config.before(:each) do
+    allow_any_instance_of(Nib::History::Compose).to receive(:original_config) do
+      DEFAULT_COMPOSE
+    end
+  end
+end

--- a/spec/unit/history/compose_spec.rb
+++ b/spec/unit/history/compose_spec.rb
@@ -1,0 +1,27 @@
+RSpec.describe Nib::History::Compose do
+  let(:history_config) { 'nib_history:/usr/local/history' }
+
+  before do
+    allow(subject).to receive(:original_config) do
+      fixture_name = self.class.description.tr(' ', '_')
+
+      YAML.load_file("./spec/fixtures/compose/#{fixture_name}.yml")
+    end
+  end
+
+  context 'with existing volumes key' do
+    it 'adds the history volume' do
+      subject.config['services'].each do |_, definition|
+        expect(definition['volumes']).to include(history_config)
+      end
+    end
+  end
+
+  context 'without existing volumes key' do
+    it 'adds the history volume' do
+      subject.config['services'].each do |_, definition|
+        expect(definition['volumes']).to include(history_config)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Previously we used `./tmp` which worked for most cases however:

* If a project did not `gitignore` the `./tmp` folder users would see unexpected files in there diff (ie. `./tmp/shell_history`)
* Some users are running containers on an external machine and are not able to bind mount the local directory into the container.

This code now creates a history volume per project, mounts that new volume into each service (at `/usr/local/history`) and writes history files to it.