### PR TITLE
Use latest version of code-climate-test-reporter

### DIFF
--- a/nib.gemspec
+++ b/nib.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency('guard-rspec')
   s.add_development_dependency('guard-rubocop')
   s.add_development_dependency('simplecov')
-  s.add_development_dependency('codeclimate-test-reporter', '~> 1.0.5')
+  s.add_development_dependency('codeclimate-test-reporter', '~> 1.0.6')
 end


### PR DESCRIPTION
A recent release will (hopefully) fix issues with reporting test coverage from Codeship.

https://github.com/codeclimate/ruby-test-reporter/pull/172