### PR TITLE
Use CMD if argument not passed to `run`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [#123](https://github.com/technekes/nib/pull/123) Favor Docker over Compose for CodeClimate command - [@johnallen3d](https://github.com/johnallen3d).
 * [#129](https://github.com/technekes/nib/pull/129) Upgrade `shell` command - [@johnallen3d](https://github.com/johnallen3d).
+* [#130](https://github.com/technekes/nib/pull/130) Use CMD if argument not passed to `run` - [@johnallen3d](https://github.com/johnallen3d).
 
 # 1.4.2 (2017-02-23)
 

--- a/lib/nib/history.rb
+++ b/lib/nib/history.rb
@@ -1,7 +1,25 @@
 require 'fileutils'
 
 module Nib::History
+  def self.prepended(base)
+    base.instance_eval do
+      extend ClassMethods
+    end
+  end
+
+  module ClassMethods
+    def history_requires_command(value)
+      @history_requires_command = value
+    end
+
+    def history_requires_command?
+      @history_requires_command
+    end
+  end
+
   def command
+    return if self.class.history_requires_command? && @command.to_s.empty?
+
     <<-COMMAND
       /bin/sh -c \"
         export HISTFILE=./tmp/shell_history

--- a/lib/nib/run.rb
+++ b/lib/nib/run.rb
@@ -1,4 +1,6 @@
 class Nib::Run
   include Nib::Command
   prepend Nib::History
+
+  history_requires_command true
 end

--- a/spec/unit/run_spec.rb
+++ b/spec/unit/run_spec.rb
@@ -4,19 +4,31 @@ RSpec.describe Nib::Run do
 
   subject { described_class.new(service, command) }
 
-  it 'inserts the --rm arg' do
-    expect(subject.script).to match(
-      /
-        docker-compose
-        .*
-        run
-        .*
-        --rm
-        .*
-        #{service}
-        (.|\n)*
-        #{command}$
-      /x
-    )
+  context 'with a command specified' do
+    it 'inserts the --rm arg and includes history' do
+      expect(subject.script).to match(
+        /
+          docker-compose
+          .*
+          run
+          .*
+          --rm
+          .*
+          #{service}
+          (.|\n)*
+          export\sHISTFILE
+          (.|\n)*
+          #{command}$
+        /x
+      )
+    end
+  end
+
+  context 'without a command specified' do
+    let(:command) { nil }
+
+    it 'does not include history' do
+      expect(subject.script).to_not include('HISTORY')
+    end
   end
 end


### PR DESCRIPTION
The introduction of history to the `run` command introduced a regression where if an argument was not passed to `run` the container would exit immediately. Now the `run` command will check to see if a command is specified and only hook up history if so.

Resolves #127