### PR TITLE
Viva la Alpine image!

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,75 @@
-FROM ruby:2.2
+FROM alpine:3.5
 
-ENV COMPOSE_VERSION 1.10.0
-
-RUN \
-  gem install rainbow -v '2.2.1' && \
-  curl -fsSL https://get.docker.com/ | sh && \
-  curl -L https://github.com/docker/compose/releases/download/$COMPOSE_VERSION/docker-compose-`uname -s`-`uname -m` > /usr/local/bin/docker-compose && \
-  chmod +x /usr/local/bin/docker-compose
+ARG DOCKER_VERSION=1.13.1
+ARG COMPOSE_VERSION=1.11.2
 
 WORKDIR /usr/src/app
 
-COPY Gemfile* ./
-COPY VERSION ./VERSION
-COPY lib/nib/version.rb ./lib/nib/version.rb
-COPY nib.gemspec ./nib.gemspec
-
-RUN \
-  gem install bundler && \
-  bundle install -j4
-
 COPY . .
 
-CMD rspec spec
+RUN \
+  # install dev dependencies
+  apk --no-cache add \
+    bash \
+    build-base \
+    git \
+    libffi-dev \
+    py-pip \
+    python \
+    ruby \
+    ruby-bundler \
+    ruby-dev \
+    wget && \
+
+  # install docker
+  mkdir /code && \
+  cd /code && \
+  wget \
+    --no-check-certificate \
+    -qO- \
+    https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz \
+    | tar xvz && \
+  mv docker/docker /usr/local/bin && \
+
+  # install docker-compose
+  git \
+    clone \
+    --branch ${COMPOSE_VERSION} \
+    https://github.com/docker/compose.git \
+    /code/compose && \
+  cd /code/compose && \
+  pip \
+    --no-cache-dir install \
+    -r requirements.txt \
+    -r requirements-dev.txt \
+    pyinstaller==3.1.1 && \
+  git rev-parse --short HEAD > compose/GITSHA && \
+  ln -s /lib /lib64 && \
+  ln -s /lib/libc.musl-x86_64.so.1 ldd && \
+  ln -s /lib/ld-musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2 && \
+  pyinstaller docker-compose.spec && \
+  unlink /lib/ld-linux-x86-64.so.2 /lib64 ldd || true && \
+  mv dist/docker-compose /usr/local/bin/docker-compose && \
+  chmod +x /usr/local/bin/docker-compose && \
+
+  # install ruby dependencies
+  bundle install --gemfile=/usr/src/app/Gemfile --clean -j4 && \
+
+  # cleanup
+  pip freeze | xargs pip uninstall -y && \
+
+  apk del \
+    bash \
+    build-base \
+    ca-certificates \
+    git \
+    libffi-dev \
+    py-pip \
+    python \
+    ruby-dev && \
+
+  rm -rf /code /usr/lib/python2.7/ /root/.cache /var/cache/apk/* && \
+  rm -rf /usr/lib/ruby/gems/*/cache/* && \
+  rm -rf /var/cache/apk/* /tmp
+
+CMD rake rspec:unit

--- a/bin/ci
+++ b/bin/ci
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /bin/sh
 
 set -e
 

--- a/bin/release
+++ b/bin/release
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /bin/sh
 
 # update commands document
 docker run \

--- a/spec/dummy/rails/bin/setup
+++ b/spec/dummy/rails/bin/setup
@@ -1,3 +1,3 @@
-#! /bin/bash
+#! /bin/sh
 
 echo "hello from setup proper"

--- a/spec/dummy/rails/bin/setup.after.stub
+++ b/spec/dummy/rails/bin/setup.after.stub
@@ -1,3 +1,3 @@
-#! /bin/bash
+#! /bin/sh
 
 echo "hello from setup.after"

--- a/spec/dummy/rails/bin/setup.before.stub
+++ b/spec/dummy/rails/bin/setup.before.stub
@@ -1,3 +1,3 @@
-#! /bin/bash
+#! /bin/sh
 
 echo "hello from setup.before"

--- a/spec/integration/bundle_spec.rb
+++ b/spec/integration/bundle_spec.rb
@@ -1,6 +1,6 @@
 require 'serverspec_helper'
 
-RSpec.describe command('cd spec/dummy/rails && nib bundle web help') do
+RSpec.describe command("cd spec/dummy/rails && #{NIB_BIN} bundle web help") do
   its(:stdout) { should match(/BUNDLE\(1\)/) }
   its(:exit_status) { should eq 0 }
 end

--- a/spec/integration/codeclimate_spec.rb
+++ b/spec/integration/codeclimate_spec.rb
@@ -1,6 +1,6 @@
 require 'serverspec_helper'
 
-cmd = 'cd spec/dummy/rails && nib codeclimate web --help'
+cmd = "cd spec/dummy/rails && #{NIB_BIN} codeclimate web --help"
 
 RSpec.describe command(cmd) do
   its(:stdout) { should match(/Usage: codeclimate COMMAND/) }

--- a/spec/integration/console_spec.rb
+++ b/spec/integration/console_spec.rb
@@ -2,7 +2,7 @@ require 'pty'
 require 'expect'
 
 RSpec.describe 'console', :interactive do
-  let(:command) { "cd #{spec_dir} && nib console web" }
+  let(:command) { "cd #{spec_dir} && #{NIB_BIN} console web" }
 
   context 'rails' do
     let(:spec_dir) { './spec/dummy/rails' }

--- a/spec/integration/debug_spec.rb
+++ b/spec/integration/debug_spec.rb
@@ -2,7 +2,7 @@ require 'expect'
 
 RSpec.describe 'debug', :interactive, :running_rails_server do
   let(:spec_dir) { './spec/dummy/rails' }
-  let(:command)  { "cd #{spec_dir} && nib debug web" }
+  let(:command)  { "cd #{spec_dir} && #{NIB_BIN} debug web" }
 
   it 'connects to a running debug server' do
     tty(command, true) do |stdout, _|

--- a/spec/integration/exec_spec.rb
+++ b/spec/integration/exec_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'exec', :running_rails_server do
-  describe command("cd spec/dummy/rails; nib exec web 'ps x'") do
+  describe command("cd spec/dummy/rails; #{NIB_BIN} exec web 'ps x'") do
     its(:stdout) { should match(%r{\/bin\/rackup\ -p}) }
     its(:exit_status) { should eq 0 }
   end

--- a/spec/integration/guard_spec.rb
+++ b/spec/integration/guard_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe command('cd spec/dummy/rails && nib guard web --help') do
+RSpec.describe command("cd spec/dummy/rails && #{NIB_BIN} guard web --help") do
   its(:stdout) { should match(/Starts Guard/) }
   its(:exit_status) { should eq 0 }
 end

--- a/spec/integration/rails_spec.rb
+++ b/spec/integration/rails_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe command('cd spec/dummy/rails && nib rails web --help') do
+RSpec.describe command("cd spec/dummy/rails && #{NIB_BIN} rails web --help") do
   its(:stdout) { should match(/rails new APP_PATH/) }
   its(:exit_status) { should eq 0 }
 end

--- a/spec/integration/rake_spec.rb
+++ b/spec/integration/rake_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe command('cd spec/dummy/rails && nib rake web --help') do
+RSpec.describe command("cd spec/dummy/rails && #{NIB_BIN} rake web --help") do
   its(:stdout) { should match(/rake \[-f rakefile\]/) }
   its(:exit_status) { should eq 0 }
 end

--- a/spec/integration/rspec_spec.rb
+++ b/spec/integration/rspec_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe command('cd spec/dummy/rails && nib rspec web --help') do
+RSpec.describe command("cd spec/dummy/rails && #{NIB_BIN} rspec web --help") do
   its(:stdout) { should match(/Usage: rspec/) }
   its(:exit_status) { should eq 0 }
 end

--- a/spec/integration/rubocop_spec.rb
+++ b/spec/integration/rubocop_spec.rb
@@ -1,4 +1,6 @@
-RSpec.describe command('cd spec/dummy/rails && nib rubocop web --help') do
+cmd = "cd spec/dummy/rails && #{NIB_BIN} rubocop web --help"
+
+RSpec.describe command(cmd) do
   its(:stdout) { should match(/Usage: rubocop/) }
   its(:exit_status) { should eq 0 }
 end

--- a/spec/integration/run_spec.rb
+++ b/spec/integration/run_spec.rb
@@ -1,4 +1,6 @@
-RSpec.describe command('cd spec/dummy/rails && nib run web rspec --help') do
+cmd = "cd spec/dummy/rails && #{NIB_BIN} run web rspec --help"
+
+RSpec.describe command(cmd) do
   its(:stdout) { should match(/Usage: rspec/) }
   its(:exit_status) { should eq 0 }
 end

--- a/spec/integration/setup_spec.rb
+++ b/spec/integration/setup_spec.rb
@@ -1,4 +1,4 @@
-cmd = 'cd spec/dummy/rails; nib setup web'
+cmd = "cd spec/dummy/rails; #{NIB_BIN} setup web"
 
 RSpec.describe 'setup' do
   let(:bin_path) { './spec/dummy/rails/bin' }

--- a/spec/integration/shell_spec.rb
+++ b/spec/integration/shell_spec.rb
@@ -2,7 +2,7 @@ require 'pty'
 require 'expect'
 
 RSpec.describe 'shell', :interactive do
-  let(:command) { "cd #{spec_dir} && nib shell web" }
+  let(:command) { "cd #{spec_dir} && #{NIB_BIN} shell web" }
 
   context 'binstub shell override' do
     let(:spec_dir) { './spec/dummy/rails' }

--- a/spec/serverspec_helper.rb
+++ b/spec/serverspec_helper.rb
@@ -1,3 +1,5 @@
 require 'serverspec'
 
 set :backend, :exec
+
+NIB_BIN = 'RUBYLIB=/usr/src/app/lib /usr/src/app/bin/nib'.freeze


### PR DESCRIPTION
Switches back to an Alpine based image for dev/ci. The result is from an 800+mb image down to 74mb and the image builds in ~1min.

Some notes:

* The currently available version of Ruby on APK is 2.3.3. This is an upgrade from what we were previously using (2.2.x). The reason we were using 2.2 was we wanted the gem to be backward compatible to that version.
* Previously integration specs were relying on `nib` to be available on the PATH. This is not the case in this image (not sure why) so I've edited the integration specs to point to `/usr/src/app/bin/nib` via a constant (`NIB_BIN`).