### PR TITLE
Handle `$` in docker-compose config

### DIFF
--- a/lib/nib/history/compose.rb
+++ b/lib/nib/history/compose.rb
@@ -23,8 +23,12 @@ class Nib::History::Compose
 
   private
 
+  def docker_compose_config
+    @docker_compose_config ||= `docker-compose config`
+  end
+
   def original_config
-    @original_config ||= YAML.safe_load(`docker-compose config`)
+    @original_config ||= YAML.safe_load(docker_compose_config.gsub(/\$/, '$$'))
   end
 
   def file

--- a/spec/fixtures/compose/with_a_literal_dollar.yml
+++ b/spec/fixtures/compose/with_a_literal_dollar.yml
@@ -1,0 +1,18 @@
+networks: {}
+services:
+  redis:
+    image: redis:alpine
+    network_mode: bridge
+    ports:
+    - 6379:6379
+  web:
+    build:
+      context: /dev/nib
+    environment:
+      FOO: hello$world
+    network_mode: bridge
+    volumes:
+    - /dev/nib:/usr/src/app:rw
+version: '2.1'
+volumes: {}
+

--- a/spec/support/setup.rb
+++ b/spec/support/setup.rb
@@ -1,11 +1,11 @@
-DEFAULT_COMPOSE = YAML.load_file(
+DEFAULT_COMPOSE = File.read(
   'spec/fixtures/compose/with_existing_volumes_key.yml'
 )
 
 RSpec.configure do |config|
   config.before(:each) do
-    allow_any_instance_of(Nib::History::Compose).to receive(:original_config) do
-      DEFAULT_COMPOSE
-    end
+    allow_any_instance_of(Nib::History::Compose).to(
+      receive(:docker_compose_config).and_return(DEFAULT_COMPOSE)
+    )
   end
 end

--- a/spec/unit/history/compose_spec.rb
+++ b/spec/unit/history/compose_spec.rb
@@ -2,10 +2,10 @@ RSpec.describe Nib::History::Compose do
   let(:history_config) { 'nib_history:/usr/local/history' }
 
   before do
-    allow(subject).to receive(:original_config) do
+    allow(subject).to receive(:docker_compose_config) do
       fixture_name = self.class.description.tr(' ', '_')
 
-      YAML.load_file("./spec/fixtures/compose/#{fixture_name}.yml")
+      File.read("./spec/fixtures/compose/#{fixture_name}.yml")
     end
   end
 
@@ -22,6 +22,12 @@ RSpec.describe Nib::History::Compose do
       subject.config['services'].each do |_, definition|
         expect(definition['volumes']).to include(history_config)
       end
+    end
+  end
+
+  context 'with a literal dollar' do
+    it 'escapes with double dollar' do
+      expect(subject.config.to_s).to include('$$')
     end
   end
 end


### PR DESCRIPTION
In situations where `$` is present in the result of `docker-compose config` we need to escape because we are recreating a `docker-compose.yml`. If not `docker-compose` is attempting variable substitution.

Resolves #134