### PR TITLE
Support running `rake release`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN \
     ruby \
     ruby-bundler \
     ruby-dev \
+    openssh \
     wget && \
 
   # install docker
@@ -62,7 +63,6 @@ RUN \
     bash \
     build-base \
     ca-certificates \
-    git \
     libffi-dev \
     py-pip \
     python \


### PR DESCRIPTION
In order to run the `rake release` task two additional dependencies need to be present in the container that we are building.