### PR TITLE
Support images with an ENTRYPOINT for `shell` command

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,12 +40,21 @@ Style/AlignParameters:
   # end
   EnforcedStyle: with_fixed_indentation
 
+Style/MultilineMethodCallIndentation:
+  # allow for multi-line method chaining to have normal indentation.
+  # for example:
+  #
+  # Person
+  #   .where(first_name: 'tom')
+  #   .not(last_name: 'foolery')
+  EnforcedStyle: indented
+
 Lint/EndAlignment:
   EnforcedStyleAlignWith: variable
 
 ClassAndModuleChildren:
   # ok to use compact style when modules are predefined.
-  # for example the following is fine so long as we're sure that 
+  # for example the following is fine so long as we're sure that
   # module MDB has already been required/defined.
   #
   # class MDB::Person; end

--- a/lib/nib/command.rb
+++ b/lib/nib/command.rb
@@ -29,6 +29,7 @@ module Nib::Command
         #{alternate_compose_file} \
         run \
         --rm \
+        #{entrypoint} \
         #{options} \
         #{service} \
         #{command}
@@ -36,4 +37,6 @@ module Nib::Command
   end
 
   def alternate_compose_file; end
+
+  def entrypoint; end
 end

--- a/lib/nib/history.rb
+++ b/lib/nib/history.rb
@@ -17,17 +17,21 @@ module Nib::History
     end
   end
 
-  def command
-    return if self.class.history_requires_command? && @command.to_s.empty?
-
+  def wrap(executable)
     <<-COMMAND
       /bin/sh -c \"
         export HISTFILE=#{PATH}/shell_history
         cp #{irbrc.container_path} /root/.irbrc 2>/dev/null
         cp #{pryrc.container_path} /root/.pryrc 2>/dev/null
-        #{super}
+        #{executable}
       \"
     COMMAND
+  end
+
+  def command
+    return if self.class.history_requires_command? && @command.to_s.empty?
+
+    wrap(super)
   end
 
   def alternate_compose_file

--- a/lib/nib/shell.rb
+++ b/lib/nib/shell.rb
@@ -4,14 +4,16 @@ class Nib::Shell
 
   private
 
-  def command
+  def entrypoint
     conditions = %i(zsh bash ash).map do |shell|
       "elif hash #{shell} 2>/dev/null ; then #{shell};"
     end
 
-    conditions                                         # default conditions
+    executable = conditions                            # default conditions
       .unshift('if [ -f bin/shell ]; then bin/shell;') # prepend bin/shell
       .push('else sh; fi')                             # add else clause (`sh`)
       .join("\n")
+
+    "--entrypoint='#{wrap(executable)}'"
   end
 end

--- a/spec/unit/shell_spec.rb
+++ b/spec/unit/shell_spec.rb
@@ -13,9 +13,11 @@ RSpec.describe Nib::Shell do
           .*
           --rm
           .*
-          #{service}
-          .*
+          --entrypoint=
+          (.|\n)*
           /bin/sh\s-c
+          (.|\n)*
+          export\sHISTFILE
           (.|\n)*
           bin\/shell
           (.|\n)*
@@ -26,6 +28,8 @@ RSpec.describe Nib::Shell do
           ash
           (.|\n)*
           sh
+          (.|\n)*
+          #{service}
         }x
       )
     end


### PR DESCRIPTION
The new and improved `shell` command will now generate a statement that looks like this:

```sh
docker-compose \
  -f /tmp/nib/compose20170605-237-1y7p1o1 \
  run \
  --rm \
  --entrypoint='
    /bin/sh -c "
      export HISTFILE=/usr/local/history/shell_history
      cp /tmp/nib/config/irbrc /root/.irbrc 2>/dev/null
      cp /tmp/nib/config/pryrc /root/.pryrc 2>/dev/null
      if [ -f bin/shell ]; then bin/shell;
      elif hash zsh 2>/dev/null ; then zsh;
      elif hash bash 2>/dev/null ; then bash;
      elif hash ash 2>/dev/null ; then ash;
      else sh; fi
      "
  ' \
  web \
  /bin/sh -c "
    export HISTFILE=/usr/local/history/shell_history
    cp /tmp/nib/config/irbrc /root/.irbrc 2>/dev/null
    cp /tmp/nib/config/pryrc /root/.pryrc 2>/dev/null
  "
```

Not that the trailing "`CMD`" will be completely ignored because the `ENTRYPOINT` does not accept arguments. I believe this is desired and is essentially the current behavior. 

Resolves #143