### PR TITLE
Add history volume for delegated commands

### DIFF
--- a/bin/nib
+++ b/bin/nib
@@ -47,7 +47,7 @@ on_error do |exception|
   case exception
   when GLI::UnknownCommand
     # delegate unknown commands over to `docker-compose`
-    exec("docker-compose #{ARGV.join(' ')}")
+    exec("docker-compose -f #{Nib::History::Compose.new.path} #{ARGV.join(' ')}")
 
     false
   else


### PR DESCRIPTION
For commands not handled by `nib` this will ensure that the special "history volume" is in place. This is helpful for the scenario where the user does a `nib up -d && nib exec web`.

Resolves #144