### PR TITLE
Strip indentation from heredocs

### DIFF
--- a/lib/core_extensions/string.rb
+++ b/lib/core_extensions/string.rb
@@ -1,0 +1,6 @@
+class String
+  # Implementation from active_support https://git.io/vNVlN
+  def strip_heredoc
+    gsub(/^#{scan(/^[ \t]*(?=\S)/).min}/, ''.freeze)
+  end
+end

--- a/lib/nib.rb
+++ b/lib/nib.rb
@@ -1,6 +1,7 @@
 require 'nib/version'
 
 require 'core_extensions/hash'
+require 'core_extensions/string'
 
 require 'nib/options'
 require 'nib/options/augmenter'

--- a/lib/nib/check_for_update.rb
+++ b/lib/nib/check_for_update.rb
@@ -4,10 +4,10 @@ class Nib::CheckForUpdate
   def self.execute(_, _)
     return if installed == latest
 
-    puts <<-MESSAGE
+    puts <<-MESSAGE.strip_heredoc
 
-    An update is available for nib: #{latest}
-    Use 'nib update' to install the latest version
+      An update is available for nib: #{latest}
+      Use 'nib update' to install the latest version
     MESSAGE
   end
 

--- a/lib/nib/unrecognized_help.rb
+++ b/lib/nib/unrecognized_help.rb
@@ -1,6 +1,6 @@
 class Nib::UnrecognizedHelp
   def self.execute(_, _)
-    puts <<-MESSAGE
+    puts <<-MESSAGE.strip_heredoc
 
       Note:
         Unrecognized commands will be delegated to docker-compose.


### PR DESCRIPTION
A change to make nib work with Ruby 2.2 (16cc0bf07683fa0833c3a8677f437ea0e7ac6011) removed the "squiggly heredoc" syntax but did not account for the fact that printed heredocs would now be indented.