### PR TITLE
Print a list of installed plugins with help

### DIFF
--- a/bin/nib
+++ b/bin/nib
@@ -37,6 +37,7 @@ post do |global, command, options, args|
   # Use skips_post before a command to skip this
   # block on that command only
   if command.is_a? GLI::Commands::Help
+    Nib::Plugins.execute(options, args)
     Nib::UnrecognizedHelp.execute(options, args)
     Nib::CheckForUpdate.execute(options, args)
   end

--- a/lib/nib.rb
+++ b/lib/nib.rb
@@ -7,6 +7,9 @@ require 'nib/options'
 require 'nib/options/augmenter'
 require 'nib/options/parser'
 
+require 'nib/plugins'
+require 'nib/plugin'
+
 require 'nib/command'
 require 'nib/history'
 require 'nib/history/compose'
@@ -27,22 +30,12 @@ module Nib
 
   module_function
 
-  def available_plugins
-    Gem.find_files('nib*_plugin.rb').sort.map do |plugin_path|
-      name = File.basename plugin_path, '_plugin.rb'
-
-      require plugin_path
-
-      next unless const_for(name).applies?
-
-      plugin_base_path = plugin_path[0..-"/lib/#{name}_plugin.rb".length]
-
-      "#{plugin_base_path}bin/#{name.tr('_', '-')}"
-    end.compact
+  def installed_plugins
+    Nib::Plugins.potential_plugins.map(&:name)
   end
 
-  def const_for(name)
-    Nib.const_get(name.split('_').map(&:capitalize).join('::'))
+  def available_plugins
+    Nib::Plugins.available_plugins.map(&:binstub)
   end
 
   def load_default_config(command, file_name)

--- a/lib/nib/plugin.rb
+++ b/lib/nib/plugin.rb
@@ -1,0 +1,31 @@
+class Nib::Plugin
+  attr_reader :path
+
+  def initialize(path)
+    @path = path
+  end
+
+  def basename
+    @basename ||= File.basename(path, '_plugin.rb')
+  end
+
+  def name
+    @name ||= basename.tr('_', '-')
+  end
+
+  def constant
+    @constant ||= Object.const_get(name.split('-').map(&:capitalize).join('::'))
+  end
+
+  def applies?
+    @applies ||= begin
+      require path
+
+      constant.applies?
+    end
+  end
+
+  def binstub
+    "#{path[0..-"/lib/#{basename}_plugin.rb".length]}bin/#{name}"
+  end
+end

--- a/lib/nib/plugins.rb
+++ b/lib/nib/plugins.rb
@@ -1,0 +1,20 @@
+class Nib::Plugins
+  def self.execute(_, _)
+    puts ''
+    puts(
+      (['Installed plugins:'] | potential_plugins.map(&:name))
+      .join("\r\n  - ")
+    )
+  end
+
+  def self.potential_plugins
+    @potential_plugins ||= Gem
+      .find_files('nib*_plugin.rb')
+      .sort
+      .map { |plugin_path| Nib::Plugin.new(plugin_path) }
+  end
+
+  def self.available_plugins
+    @available_plugins ||= potential_plugins.select(&:applies?)
+  end
+end

--- a/spec/unit/nib_spec.rb
+++ b/spec/unit/nib_spec.rb
@@ -12,6 +12,12 @@ RSpec.describe Nib do
   it 'search gems to find installed plugins' do
     allow(Gem).to receive(:find_files) { plugins }
 
+    expect(subject.installed_plugins).to include('nib-ruby')
+  end
+
+  it 'search gems to find available plugins' do
+    allow(Gem).to receive(:find_files) { plugins }
+
     expect(subject.available_plugins).to include(nib_ruby)
   end
 end


### PR DESCRIPTION
Now when a user asks for "help" the list of plugins that are installed will be printed.

Example output:

```
...
    shell       - Start a shell session in a one-off service container
    update      - Download the latest version of nib

Installed plugins:
  - nib-crypt
  - nib-heroku
  - nib-ruby

Note:
  Unrecognized commands will be delegated to docker-compose.
...
```