### PR TITLE
Handle varied Psych load API's

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,9 @@ AllCops:
 Gemspec/RequiredRubyVersion:
   Enabled: false
 
+Security/YAMLLoad:
+  Enabled: false
+
 Style/Documentation:
   # don't require classes to be documented
   Enabled: false

--- a/lib/core_extensions/psych.rb
+++ b/lib/core_extensions/psych.rb
@@ -1,0 +1,29 @@
+require 'yaml'
+
+module CoreExtensions
+  # Handle the fact that we are loading potentially "unsafe" YAML while still
+  # supporting Ruby 2.7 and 3.0.
+  module Psych
+    def flexible_load(string)
+      load_with = if ::Psych.respond_to?(:unsafe_load)
+        :unsafe_load
+      else
+        :load
+      end
+
+      ::Psych.send(load_with, string)
+    end
+
+    def flexible_load_file(path)
+      load_with = if ::Psych.respond_to?(:unsafe_load_file)
+        :unsafe_load_file
+      else
+        :load_file
+      end
+
+      ::Psych.send(load_with, path)
+    end
+  end
+end
+
+Psych.extend CoreExtensions::Psych

--- a/lib/nib.rb
+++ b/lib/nib.rb
@@ -2,6 +2,7 @@ require 'nib/version'
 
 require 'core_extensions/hash'
 require 'core_extensions/string'
+require 'core_extensions/psych'
 
 require 'nib/options'
 require 'nib/options/augmenter'

--- a/lib/nib/debug.rb
+++ b/lib/nib/debug.rb
@@ -1,5 +1,3 @@
-require 'yaml'
-
 class Nib::Debug
   include Nib::Command
 

--- a/lib/nib/history/compose.rb
+++ b/lib/nib/history/compose.rb
@@ -28,7 +28,9 @@ class Nib::History::Compose
   end
 
   def original_config
-    @original_config ||= YAML.safe_load(docker_compose_config.gsub(/\$/, '$$'))
+    @original_config ||= Psych.flexible_load(
+      docker_compose_config.gsub(/\$/, '$$')
+    )
   end
 
   def file

--- a/lib/nib/options.rb
+++ b/lib/nib/options.rb
@@ -4,13 +4,7 @@ module Nib::Options
   def config
     return @config if @config
 
-    load_with = if YAML.respond_to?(:unsafe_load_file)
-      :unsafe_load_file
-    else
-      :load_file
-    end
-
-    @config = YAML.send(load_with, "#{Nib::GEM_ROOT}/config/options.yml")
+    @config = Psych.flexible_load_file("#{Nib::GEM_ROOT}/config/options.yml")
   end
 
   def options_for(type, name)


### PR DESCRIPTION
The API for the version of Psych that ships with currently supported versions of Ruby (2.7, 3.0, 3.1) are slightly different when it comes to loading potentially "unsafe" YAML content. Rather than forcing users to the latest version this monkey-patch tries do deal with these inconsistencies in a natural way.

Fixes #168
